### PR TITLE
Add XML documentation across projects, rename AppServices setup, and add search engine tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Depending on how large the project is, you may want to outsource the questioning
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version.
-- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/itsarisid/sand-castle/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,27 @@ Groups and endpoints are organized by modules (Accounts, Authentication, Authori
 - iiwi.SearchEngine — search engine components
 - iiwi.Scheduler — background jobs (Quartz)
 
+## Project structure
+
+```
+iiwi/
+├── iiwi.Application/        # application layer (handlers, requests, validators)
+├── iiwi.CLI/                # CLI tools for migrations and diagnostics
+├── iiwi.Common/             # shared utilities and helpers
+├── iiwi.Core/               # core abstractions and primitives
+├── iiwi.Database/           # EF Core context, migrations, repositories
+├── iiwi.Domain/             # domain entities and value objects
+├── iiwi.Infrastructure/     # infrastructure services (email, templates, etc.)
+├── iiwi.Library/            # shared library components
+├── iiwi.Model/              # DTOs and contracts
+├── iiwi.NetLine/            # web/API project (Program.cs, endpoints, config)
+├── iiwi.Scheduler/          # background jobs (Quartz)
+├── iiwi.SearchEngine/       # search engine components
+├── iiwi.SearchEngine.Tests/ # search engine unit tests
+├── iiwi.slnx                # solution file
+└── README.md
+```
+
 ---
 
 ## Common tasks and examples

--- a/iiwi.Application/Account/UpdateProfileRequest.cs
+++ b/iiwi.Application/Account/UpdateProfileRequest.cs
@@ -4,15 +4,33 @@ namespace iiwi.Application;
 
 public record UpdateProfileRequest
 {
+    /// <summary>
+    /// Gets or sets the Gender.
+    /// </summary>
     public string Gender { get; set; }
+    /// <summary>
+    /// Gets or sets the FirstName.
+    /// </summary>
     [Display(Name = "First Name")]
     public string FirstName { get; set; }
+    /// <summary>
+    /// Gets or sets the LastName.
+    /// </summary>
     [Display(Name = "Last Name")]
     public string LastName { get; set; }
+    /// <summary>
+    /// Gets or sets the DisplayName.
+    /// </summary>
     [Display(Name = "Display Name")]
     public string DisplayName { get; set; }
+    /// <summary>
+    /// Gets or sets the DOB.
+    /// </summary>
     [Display(Name = "Date of Birth")]
     public DateTime DOB { get; set; }
+    /// <summary>
+    /// Gets or sets the Address.
+    /// </summary>
     [Display(Name = "Address")]
     public string Address { get; set; }
 }

--- a/iiwi.Application/Account/UpdateProfileValidator.cs
+++ b/iiwi.Application/Account/UpdateProfileValidator.cs
@@ -5,6 +5,9 @@ namespace iiwi.Application.Account;
 
 public class UpdateProfileValidator:AbstractValidator<UpdateProfileRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateProfileValidator"/> class.
+    /// </summary>
     public UpdateProfileValidator()
     {
         RuleFor(request => request.FirstName).Name();

--- a/iiwi.Application/Authentication/Email/ChangeEmailRequest.cs
+++ b/iiwi.Application/Authentication/Email/ChangeEmailRequest.cs
@@ -4,6 +4,9 @@ namespace iiwi.Application.Authentication;
 
 public record ChangeEmailRequest
 {
+    /// <summary>
+    /// Gets or sets the NewEmail.
+    /// </summary>
     [Required]
     [EmailAddress]
     [Display(Name = "New email")]

--- a/iiwi.Application/Authentication/Email/ChangeEmailValidator.cs
+++ b/iiwi.Application/Authentication/Email/ChangeEmailValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class ChangeEmailValidator : AbstractValidator<ChangeEmailRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChangeEmailValidator"/> class.
+    /// </summary>
     public ChangeEmailValidator()
     {
         RuleFor(request => request.NewEmail).Email();

--- a/iiwi.Application/Authentication/Email/ConfirmEmailChangeRequest.cs
+++ b/iiwi.Application/Authentication/Email/ConfirmEmailChangeRequest.cs
@@ -4,13 +4,22 @@ namespace iiwi.Application.Authentication;
 
 public record ConfirmEmailChangeRequest
 {
+    /// <summary>
+    /// Gets or sets the UserId.
+    /// </summary>
     [Required]
     public string UserId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Code.
+    /// </summary>
     [Required]
     public string Code { get; set; }
 }

--- a/iiwi.Application/Authentication/Email/ConfirmEmailChangeValidator.cs
+++ b/iiwi.Application/Authentication/Email/ConfirmEmailChangeValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class ConfirmEmailChangeValidator : AbstractValidator<ConfirmEmailChangeRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfirmEmailChangeValidator"/> class.
+    /// </summary>
     public ConfirmEmailChangeValidator()
     {
         RuleFor(request => request.Email).Email();

--- a/iiwi.Application/Authentication/Email/ConfirmEmailRequest.cs
+++ b/iiwi.Application/Authentication/Email/ConfirmEmailRequest.cs
@@ -3,9 +3,15 @@ namespace iiwi.Application.Authentication;
 
 public class ConfirmEmailRequest
 {
+    /// <summary>
+    /// Gets or sets the UserId.
+    /// </summary>
     [Required]
     public string UserId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Code.
+    /// </summary>
     [Required]
     public string Code { get; set; }
 }

--- a/iiwi.Application/Authentication/Email/ConfirmEmailValidator.cs
+++ b/iiwi.Application/Authentication/Email/ConfirmEmailValidator.cs
@@ -5,6 +5,9 @@ namespace iiwi.Application.Authentication;
 
 public class ConfirmEmailValidator : AbstractValidator<ConfirmEmailRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfirmEmailValidator"/> class.
+    /// </summary>
     public ConfirmEmailValidator()
     {
         RuleFor(request => request.UserId).NotEmpty();

--- a/iiwi.Application/Authentication/Extra/AccountStatusResponse.cs
+++ b/iiwi.Application/Authentication/Extra/AccountStatusResponse.cs
@@ -2,8 +2,20 @@ namespace iiwi.Application.Authentication;
 
 public record AccountStatusResponse:Response
 {
+    /// <summary>
+    /// Gets or sets the HasAuthenticator.
+    /// </summary>
     public bool HasAuthenticator { get; set; }
+    /// <summary>
+    /// Gets or sets the Is2faEnabled.
+    /// </summary>
     public bool Is2faEnabled { get; set; }
+    /// <summary>
+    /// Gets or sets the IsMachineRemembered.
+    /// </summary>
     public bool IsMachineRemembered { get; set; }
+    /// <summary>
+    /// Gets or sets the RecoveryCodesLeft.
+    /// </summary>
     public int RecoveryCodesLeft { get; set; }
 }

--- a/iiwi.Application/Authentication/Extra/UpdatePhoneNumberRequest.cs
+++ b/iiwi.Application/Authentication/Extra/UpdatePhoneNumberRequest.cs
@@ -4,6 +4,9 @@ namespace iiwi.Application.Authentication;
 
 public record UpdatePhoneNumberRequest
 {
+    /// <summary>
+    /// Gets or sets the PhoneNumber.
+    /// </summary>
     [Required]
     [DataType(DataType.PhoneNumber)]
     public string PhoneNumber { get; set; }

--- a/iiwi.Application/Authentication/Login/ExternalLoginsResponse.cs
+++ b/iiwi.Application/Authentication/Login/ExternalLoginsResponse.cs
@@ -4,10 +4,22 @@ using Microsoft.AspNetCore.Identity;
 namespace iiwi.Application.Authentication;
 
 public record ExternalLoginsResponse : Response { 
+    /// <summary>
+    /// Gets or sets the CurrentLogins.
+    /// </summary>
     public IList<UserLoginInfo> CurrentLogins { get; set; }
 
+    /// <summary>
+    /// Gets or sets the OtherLogins.
+    /// </summary>
     public IList<AuthenticationScheme> OtherLogins { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ShowRemoveButton.
+    /// </summary>
     public bool ShowRemoveButton { get; set; }
+    /// <summary>
+    /// Gets or sets the StatusMessage.
+    /// </summary>
     public string StatusMessage { get; set; }
 }

--- a/iiwi.Application/Authentication/Login/LinkLoginRequest.cs
+++ b/iiwi.Application/Authentication/Login/LinkLoginRequest.cs
@@ -4,6 +4,9 @@ namespace iiwi.Application.Authentication;
 
 public record LinkLoginRequest
 {
+    /// <summary>
+    /// Gets or sets the Provider.
+    /// </summary>
     [Required]
     public string Provider { get; set; }
 }

--- a/iiwi.Application/Authentication/Login/LoginRequest.cs
+++ b/iiwi.Application/Authentication/Login/LoginRequest.cs
@@ -4,14 +4,23 @@ namespace iiwi.Application.Authentication
 {
     public record LoginRequest
     {
+        /// <summary>
+        /// Gets or sets the Email.
+        /// </summary>
         [Required]
         [EmailAddress]
         public string Email { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Password.
+        /// </summary>
         [Required]
         [DataType(DataType.Password)]
         public string Password { get; set; }
 
+        /// <summary>
+        /// Gets or sets the RememberMe.
+        /// </summary>
         [Display(Name = "Remember me?")]
         public bool RememberMe { get; set; }
     }

--- a/iiwi.Application/Authentication/Login/LoginRequestValidator.cs
+++ b/iiwi.Application/Authentication/Login/LoginRequestValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class LoginRequestValidator : AbstractValidator<LoginRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginRequestValidator"/> class.
+    /// </summary>
     public LoginRequestValidator()
     {
         RuleFor(request => request.Email).Email();

--- a/iiwi.Application/Authentication/Login/LoginResponse.cs
+++ b/iiwi.Application/Authentication/Login/LoginResponse.cs
@@ -4,6 +4,12 @@ using System.IdentityModel.Tokens.Jwt;
 namespace iiwi.Application.Authentication;
 public record LoginResponse : Response
 {
+    /// <summary>
+    /// Gets or sets the FullName.
+    /// </summary>
     public string FullName { get; set; }
+    /// <summary>
+    /// Gets or sets the Token.
+    /// </summary>
     public string Token { get; set; }
 }

--- a/iiwi.Application/Authentication/Login/LoginWith2faRequest.cs
+++ b/iiwi.Application/Authentication/Login/LoginWith2faRequest.cs
@@ -4,12 +4,18 @@ namespace iiwi.Application.Authentication;
 
 public record LoginWith2faRequest
 {
+    /// <summary>
+    /// Gets or sets the TwoFactorCode.
+    /// </summary>
     [Required]
     [StringLength(7, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Text)]
     [Display(Name = "Authenticator code")]
     public string TwoFactorCode { get; set; }
 
+    /// <summary>
+    /// Gets or sets the RememberMachine.
+    /// </summary>
     [Display(Name = "Remember this machine")]
     public bool RememberMachine { get; set; }
 }

--- a/iiwi.Application/Authentication/Login/LoginWith2faValidator.cs
+++ b/iiwi.Application/Authentication/Login/LoginWith2faValidator.cs
@@ -5,6 +5,9 @@ namespace iiwi.Application.Authentication;
 
 internal class LoginWith2faValidator : AbstractValidator<LoginWith2faRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginWith2faValidator"/> class.
+    /// </summary>
     public LoginWith2faValidator()
     {
         RuleFor(request => request.TwoFactorCode).NotEmpty();

--- a/iiwi.Application/Authentication/Login/LoginWithRecoveryCodeRequest.cs
+++ b/iiwi.Application/Authentication/Login/LoginWithRecoveryCodeRequest.cs
@@ -5,6 +5,9 @@ namespace iiwi.Application.Authentication;
 
 public record LoginWithRecoveryCodeRequest
 {
+    /// <summary>
+    /// Gets or sets the RecoveryCode.
+    /// </summary>
     [Required]
     [DataType(DataType.Text)]
     [Display(Name = "Recovery Code")]

--- a/iiwi.Application/Authentication/Login/LoginWithRecoveryCodeValidator.cs
+++ b/iiwi.Application/Authentication/Login/LoginWithRecoveryCodeValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class LoginWithRecoveryCodeValidator : AbstractValidator<LoginWithRecoveryCodeRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginWithRecoveryCodeValidator"/> class.
+    /// </summary>
     public LoginWithRecoveryCodeValidator()
     {
         RuleFor(request => request.RecoveryCode).NotEmpty();

--- a/iiwi.Application/Authentication/Login/RemoveLoginRequest.cs
+++ b/iiwi.Application/Authentication/Login/RemoveLoginRequest.cs
@@ -3,6 +3,12 @@ namespace iiwi.Application.Authentication;
 
 public record RemoveLoginRequest
 {
+    /// <summary>
+    /// Gets or sets the LoginProvider.
+    /// </summary>
     public string LoginProvider { get; set; }
+    /// <summary>
+    /// Gets or sets the ProviderKey.
+    /// </summary>
     public string ProviderKey { get; set; }
 }

--- a/iiwi.Application/Authentication/Mfa/EnableAuthenticatorRequest.cs
+++ b/iiwi.Application/Authentication/Mfa/EnableAuthenticatorRequest.cs
@@ -4,6 +4,9 @@ namespace iiwi.Application.Authentication;
 
 public record EnableAuthenticatorRequest
 {
+    /// <summary>
+    /// Gets or sets the Code.
+    /// </summary>
     [Required]
     [StringLength(7, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Text)]

--- a/iiwi.Application/Authentication/Mfa/GenerateRecoveryCodesResponse.cs
+++ b/iiwi.Application/Authentication/Mfa/GenerateRecoveryCodesResponse.cs
@@ -2,5 +2,8 @@ namespace iiwi.Application.Authentication;
 
 public record GenerateRecoveryCodesResponse:Response
 {
+    /// <summary>
+    /// Gets or sets the RecoveryCodes.
+    /// </summary>
     public string[] RecoveryCodes { get; set; }
 }

--- a/iiwi.Application/Authentication/Password/ChangePasswordRequest.cs
+++ b/iiwi.Application/Authentication/Password/ChangePasswordRequest.cs
@@ -5,17 +5,26 @@ namespace iiwi.Application.Authentication;
 
 public record ChangePasswordRequest
 {
+    /// <summary>
+    /// Gets or sets the OldPassword.
+    /// </summary>
     [Required]
     [DataType(DataType.Password)]
     [Display(Name = "Current password")]
     public string OldPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the NewPassword.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "New password")]
     public string NewPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm new password")]
     [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]

--- a/iiwi.Application/Authentication/Password/ChangePasswordValidator.cs
+++ b/iiwi.Application/Authentication/Password/ChangePasswordValidator.cs
@@ -5,6 +5,9 @@ namespace iiwi.Application.Authentication;
 
 public class ChangePasswordValidator : AbstractValidator<ChangePasswordRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChangePasswordValidator"/> class.
+    /// </summary>
     public ChangePasswordValidator()
     {
         RuleFor(request => request.OldPassword).Password();

--- a/iiwi.Application/Authentication/Password/ForgotPasswordRequest.cs
+++ b/iiwi.Application/Authentication/Password/ForgotPasswordRequest.cs
@@ -4,6 +4,9 @@ namespace iiwi.Application.Authentication;
 
 public record ForgotPasswordRequest
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; }

--- a/iiwi.Application/Authentication/Password/ForgotPasswordValidator.cs
+++ b/iiwi.Application/Authentication/Password/ForgotPasswordValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class ForgotPasswordValidator : AbstractValidator<ForgotPasswordRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ForgotPasswordValidator"/> class.
+    /// </summary>
     public ForgotPasswordValidator()
     {
         RuleFor(request => request.Email).Email();

--- a/iiwi.Application/Authentication/Password/ResetPasswordRequest.cs
+++ b/iiwi.Application/Authentication/Password/ResetPasswordRequest.cs
@@ -4,20 +4,32 @@ namespace iiwi.Application.Authentication;
 
 public class ResetPasswordRequest
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     public string Password { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm password")]
     [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
     public string ConfirmPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Code.
+    /// </summary>
     [Required]
     public string Code { get; set; }
 }

--- a/iiwi.Application/Authentication/Password/ResetPasswordValidator.cs
+++ b/iiwi.Application/Authentication/Password/ResetPasswordValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class ResetPasswordValidator : AbstractValidator<ForgotPasswordRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResetPasswordValidator"/> class.
+    /// </summary>
     public ResetPasswordValidator()
     {
         RuleFor(request => request.Email).Email();

--- a/iiwi.Application/Authentication/Password/SetPasswordRequest.cs
+++ b/iiwi.Application/Authentication/Password/SetPasswordRequest.cs
@@ -3,12 +3,18 @@ namespace iiwi.Application.Authentication;
 
 public record SetPasswordRequest
 {
+    /// <summary>
+    /// Gets or sets the NewPassword.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "New password")]
     public string NewPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm new password")]
     [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]

--- a/iiwi.Application/Authentication/Personal/DeletePersonalDataRequest.cs
+++ b/iiwi.Application/Authentication/Personal/DeletePersonalDataRequest.cs
@@ -5,6 +5,9 @@ namespace iiwi.Application.Authentication;
 
 public record DeletePersonalDataRequest
 {
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     [Required]
     [DataType(DataType.Password)]
     public string Password { get; set; }

--- a/iiwi.Application/Authentication/Personal/DeletePersonalDataValidator.cs
+++ b/iiwi.Application/Authentication/Personal/DeletePersonalDataValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class DeletePersonalDataValidator : AbstractValidator<DeletePersonalDataRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeletePersonalDataValidator"/> class.
+    /// </summary>
     public DeletePersonalDataValidator()
     {
         RuleFor(request => request.Password).Password();

--- a/iiwi.Application/Authentication/Personal/DownloadPersonalDataResponse.cs
+++ b/iiwi.Application/Authentication/Personal/DownloadPersonalDataResponse.cs
@@ -5,5 +5,8 @@ namespace iiw.Application.Authentication;
 
 public record DownloadPersonalDataResponse:Response
 {
+    /// <summary>
+    /// Gets or sets the Data.
+    /// </summary>
     public Dictionary<string, string> Data { get; set; }
 }

--- a/iiwi.Application/Authentication/Register/RegisterConfirmationRequest.cs
+++ b/iiwi.Application/Authentication/Register/RegisterConfirmationRequest.cs
@@ -4,6 +4,9 @@ namespace iiwi.Application.Authentication;
 
 public record RegisterConfirmationRequest
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; }

--- a/iiwi.Application/Authentication/Register/RegisterRequest.cs
+++ b/iiwi.Application/Authentication/Register/RegisterRequest.cs
@@ -3,17 +3,26 @@ using System.ComponentModel.DataAnnotations;
 namespace iiwi.Application.Authentication;
 public sealed record RegisterRequest
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     [Display(Name = "Email")]
     public string Email { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "Password")]
     public string Password { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm password")]
     [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]

--- a/iiwi.Application/Authentication/Register/RegisterRequestValidator.cs
+++ b/iiwi.Application/Authentication/Register/RegisterRequestValidator.cs
@@ -6,6 +6,9 @@ namespace iiwi.Application.Authentication;
 
 public class RegisterRequestValidator : AbstractValidator<RegisterRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegisterRequestValidator"/> class.
+    /// </summary>
     public RegisterRequestValidator()
     {
         RuleFor(request => request.Email).Email();

--- a/iiwi.Application/Authentication/Register/RegisterResponse.cs
+++ b/iiwi.Application/Authentication/Register/RegisterResponse.cs
@@ -4,6 +4,12 @@ namespace iiwi.Application.Authentication;
 
 public record RegisterResponse: Response
 {
+    /// <summary>
+    /// Gets or sets the FullName.
+    /// </summary>
     public string FullName { get; set; }
+    /// <summary>
+    /// Gets or sets the Token.
+    /// </summary>
     public JwtSecurityToken Token { get; set; }
 }

--- a/iiwi.Application/Authorization/Claim/AddClaimRequest.cs
+++ b/iiwi.Application/Authorization/Claim/AddClaimRequest.cs
@@ -5,10 +5,16 @@ namespace iiwi.Application.Authorization;
 
 public class AddClaimRequest
 {
+    /// <summary>
+    /// Gets or sets the RoleId.
+    /// </summary>
     [JsonIgnore]
     public int RoleId { get; set; }
 }
 public class AddClaimParams
 {
+    /// <summary>
+    /// Gets or sets the RoleId.
+    /// </summary>
     public int RoleId { get; set; }
 }

--- a/iiwi.Application/Authorization/Claim/GetRoleClaimsRequest.cs
+++ b/iiwi.Application/Authorization/Claim/GetRoleClaimsRequest.cs
@@ -4,10 +4,16 @@ namespace iiwi.Application.Authorization;
 
 public class GetRoleClaimsRequest
 {
+    /// <summary>
+    /// Gets or sets the RoleId.
+    /// </summary>
     [JsonIgnore]
     public int RoleId { get; set; }
 }
 public class GetRoleClaimsParams
 {
+    /// <summary>
+    /// Gets or sets the RoleId.
+    /// </summary>
     public int RoleId { get; set; }
 }

--- a/iiwi.Application/Authorization/Claim/RemoveClaimHandler.cs
+++ b/iiwi.Application/Authorization/Claim/RemoveClaimHandler.cs
@@ -14,6 +14,9 @@ public class RemoveClaimHandler(
     ) : IHandler<RemoveClaimRequest, Response>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<Response>> HandleAsync(RemoveClaimRequest request)
     {
         var roles = await _roleManager.Roles

--- a/iiwi.Application/Authorization/Claim/RemoveClaimRequest.cs
+++ b/iiwi.Application/Authorization/Claim/RemoveClaimRequest.cs
@@ -4,13 +4,25 @@ namespace iiwi.Application.Authorization;
 
 public class RemoveClaimRequest
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     [JsonIgnore]
     public int Id { get; set; }
+    /// <summary>
+    /// Gets or sets the RoleId.
+    /// </summary>
     [JsonIgnore]
     public int RoleId { get; set; }
 }
 public class RemoveClaimParams
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public int Id { get; set; }
+    /// <summary>
+    /// Gets or sets the RoleId.
+    /// </summary>
     public int RoleId { get; set; }
 }

--- a/iiwi.Application/Authorization/Permissions/PermissionHandler.cs
+++ b/iiwi.Application/Authorization/Permissions/PermissionHandler.cs
@@ -15,6 +15,9 @@ public class PermissionHandler(
     ) : IHandler<PermissionRequest, PermissionResponse>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<PermissionResponse>> HandleAsync(PermissionRequest request)
     {
         var role = await _roleManager.FindByIdAsync(request.Id);

--- a/iiwi.Application/Authorization/Permissions/PermissionRequest.cs
+++ b/iiwi.Application/Authorization/Permissions/PermissionRequest.cs
@@ -2,5 +2,8 @@
 
 public class PermissionRequest
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public string Id { get; set; }
 }

--- a/iiwi.Application/Authorization/Permissions/PermissionResponse.cs
+++ b/iiwi.Application/Authorization/Permissions/PermissionResponse.cs
@@ -3,5 +3,8 @@ namespace iiwi.Application.Authorization;
 
 public record PermissionResponse : Response
 {
+    /// <summary>
+    /// Gets or sets the Permissions.
+    /// </summary>
     public IEnumerable<string> Permissions { get; set; }
 }

--- a/iiwi.Application/Authorization/Permissions/UpdatePermissionHandler.cs
+++ b/iiwi.Application/Authorization/Permissions/UpdatePermissionHandler.cs
@@ -15,6 +15,9 @@ public class UpdatePermissionHandler(
     ) : IHandler<UpdatePermissionRequest, Response>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<Response>> HandleAsync(UpdatePermissionRequest request)
     {
         var role = await _roleManager.FindByIdAsync(request.Id);

--- a/iiwi.Application/Authorization/Permissions/UpdatePermissionRequest.cs
+++ b/iiwi.Application/Authorization/Permissions/UpdatePermissionRequest.cs
@@ -2,7 +2,13 @@
 
 public class UpdatePermissionRequest
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public string Id { get; set; }
+    /// <summary>
+    /// Gets or sets the Permissions.
+    /// </summary>
     public List<int> Permissions { get; set; }
     
 }

--- a/iiwi.Application/Authorization/Roles/AddRoleClaimHandler.cs
+++ b/iiwi.Application/Authorization/Roles/AddRoleClaimHandler.cs
@@ -15,6 +15,9 @@ public class AddRoleClaimRequestHandler(
     ) : IHandler<AddRoleClaimRequest, Response>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<Response>> HandleAsync(AddRoleClaimRequest request)
     {
         var roles = await _roleManager.Roles

--- a/iiwi.Application/Authorization/Roles/AddRoleRequest.cs
+++ b/iiwi.Application/Authorization/Roles/AddRoleRequest.cs
@@ -3,5 +3,8 @@ namespace iiwi.Application.Authorization;
 
 public class AddRoleRequest
 {
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     public string Name { get; set; } = string.Empty;
 }

--- a/iiwi.Application/Authorization/Roles/DeleteRoleHandler.cs
+++ b/iiwi.Application/Authorization/Roles/DeleteRoleHandler.cs
@@ -14,6 +14,9 @@ public class DeleteRoleRequestHandler(
     ) : IHandler<DeleteRoleRequest, Response>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<Response>> HandleAsync(DeleteRoleRequest request)
     {
         var roles = await _roleManager.Roles

--- a/iiwi.Application/Authorization/Roles/DeleteRoleRequest.cs
+++ b/iiwi.Application/Authorization/Roles/DeleteRoleRequest.cs
@@ -4,10 +4,16 @@ namespace iiwi.Application.Authorization;
 
 public class DeleteRoleRequest
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     [JsonIgnore]
     public int Id { get; set; } 
 }
 public class DeleteRoleParams
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public int Id { get; set; }
 }

--- a/iiwi.Application/Authorization/Roles/GetByIdRoleHandler.cs
+++ b/iiwi.Application/Authorization/Roles/GetByIdRoleHandler.cs
@@ -15,6 +15,9 @@ public class GetByIdRoleHandler(
     ) : IHandler<GetByIdRoleRequest, GetByIdRoleResponse>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<GetByIdRoleResponse>> HandleAsync(GetByIdRoleRequest request)
     {
         var role = await _roleManager.FindByIdAsync(request.Id);

--- a/iiwi.Application/Authorization/Roles/GetByIdRoleRequest.cs
+++ b/iiwi.Application/Authorization/Roles/GetByIdRoleRequest.cs
@@ -2,5 +2,8 @@
 
 public class GetByIdRoleRequest
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public string Id { get; set; }
 }

--- a/iiwi.Application/Authorization/Roles/GetByIdRoleResponse.cs
+++ b/iiwi.Application/Authorization/Roles/GetByIdRoleResponse.cs
@@ -8,8 +8,17 @@ namespace iiwi.Application.Authorization
 {
         public record GetByIdRoleResponse : Response
     {
+        /// <summary>
+        /// Gets or sets the Id.
+        /// </summary>
         public string Id { get; set; }
+        /// <summary>
+        /// Gets or sets the Name.
+        /// </summary>
         public string Name { get; set; }
+        /// <summary>
+        /// Gets or sets the Description.
+        /// </summary>
         public string? Description { get; set; }
     }
 }

--- a/iiwi.Application/Authorization/Roles/RoleHandler.cs
+++ b/iiwi.Application/Authorization/Roles/RoleHandler.cs
@@ -17,6 +17,9 @@ public class RoleHandler(
     ) : IHandler<RoleRequest, RoleResponse>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<RoleResponse>> HandleAsync(RoleRequest request)
     {
         var roles = await _roleManager.Roles

--- a/iiwi.Application/Authorization/Roles/UpdateRoleHandler.cs
+++ b/iiwi.Application/Authorization/Roles/UpdateRoleHandler.cs
@@ -16,6 +16,9 @@ public class UpdateRoleRequestHandler(
     ) : IHandler<UpdateRoleRequest, Response>
 {
 
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<Response>> HandleAsync(UpdateRoleRequest request)
     {
         // Expecting Id to be set via URL params merge (Helper.MergeParameters supports non-public props)

--- a/iiwi.Application/Authorization/Roles/UpdateRoleRequest.cs
+++ b/iiwi.Application/Authorization/Roles/UpdateRoleRequest.cs
@@ -4,13 +4,25 @@ namespace iiwi.Application.Authorization;
 
 public class UpdateRoleRequest
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     [JsonIgnore]
     public  int Id { get; set; }
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     public string Name { get; set; }
+    /// <summary>
+    /// Gets or sets the Description.
+    /// </summary>
     public string Description { get; set; }
 }
 
 public class UpdateRoleParams
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public int Id { get; set; }
 }

--- a/iiwi.Application/ClaimsPrincipalFactory.cs
+++ b/iiwi.Application/ClaimsPrincipalFactory.cs
@@ -10,6 +10,9 @@ public class ClaimsPrincipalFactory(
     RoleManager<ApplicationRole> roleManager,
     IOptions<IdentityOptions> optionsAccessor) : UserClaimsPrincipalFactory<ApplicationUser, ApplicationRole>(userManager, roleManager, optionsAccessor)
 {
+    /// <summary>
+    /// Executes the CreateAsync operation.
+    /// </summary>
     public override async Task<ClaimsPrincipal> CreateAsync(ApplicationUser user)
     {
         ArgumentNullException.ThrowIfNull(user);

--- a/iiwi.Application/File/Add/AddFileHandler.cs
+++ b/iiwi.Application/File/Add/AddFileHandler.cs
@@ -11,6 +11,9 @@ namespace iiwi.Application.File;
 
 public sealed record AddFileHandler : IHandler<AddFileRequest, IEnumerable<BinaryFile>>
 {
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<IEnumerable<BinaryFile>>> HandleAsync(AddFileRequest request)
     {
         var files = await request.Files.SaveAsync(General.Directories.Files);

--- a/iiwi.Application/File/Add/AddFileRequest.cs
+++ b/iiwi.Application/File/Add/AddFileRequest.cs
@@ -2,4 +2,7 @@
 
 namespace iiwi.Application.File;
 
+/// <summary>
+/// Executes the AddFileRequest operation.
+/// </summary>
 public sealed record AddFileRequest(IEnumerable<BinaryFile> Files);

--- a/iiwi.Application/File/Add/AddFileRequestValidator.cs
+++ b/iiwi.Application/File/Add/AddFileRequestValidator.cs
@@ -4,6 +4,9 @@ namespace iiwi.Application.File;
 
 public sealed class AddFileRequestValidator : AbstractValidator<AddFileRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddFileRequestValidator"/> class.
+    /// </summary>
     public AddFileRequestValidator() => RuleFor(request => request.Files).Files();
 }
 

--- a/iiwi.Application/File/Get/GetFileHandler.cs
+++ b/iiwi.Application/File/Get/GetFileHandler.cs
@@ -10,6 +10,9 @@ namespace iiwi.Application.File;
 
 public sealed record GetFileHandler : IHandler<GetFileRequest, BinaryFile>
 {
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<BinaryFile>> HandleAsync(GetFileRequest request)
     {
         var file = await BinaryFile.ReadAsync("Files", request.Id);

--- a/iiwi.Application/File/Get/GetFileRequest.cs
+++ b/iiwi.Application/File/Get/GetFileRequest.cs
@@ -1,2 +1,5 @@
 ﻿namespace iiwi.Application.File;
+/// <summary>
+/// Executes the GetFileRequest operation.
+/// </summary>
 public sealed record GetFileRequest(Guid Id);

--- a/iiwi.Application/File/Get/GetFileRequestValidator.cs
+++ b/iiwi.Application/File/Get/GetFileRequestValidator.cs
@@ -5,6 +5,9 @@ namespace iiwi.Application.Fil;
 
 public sealed class GetFileRequestValidator : AbstractValidator<GetFileRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetFileRequestValidator"/> class.
+    /// </summary>
     public GetFileRequestValidator() => RuleFor(request => request.Id).Guid();
 }
 

--- a/iiwi.Application/PingPong/SystemInfoHandler.cs
+++ b/iiwi.Application/PingPong/SystemInfoHandler.cs
@@ -15,6 +15,9 @@ public class SystemInfoHandler(
     IWebHostEnvironment hostEnvironment,
     ILogger<UpdateProfileHandler> _logger) : IHandler<EmptyRequest, SystemInfoResponse>
 {
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public async Task<Result<SystemInfoResponse>> HandleAsync(EmptyRequest request)
     {
         _logger.LogWarning("Ping pong service called.");

--- a/iiwi.Application/PingPong/SystemInfoResponse.cs
+++ b/iiwi.Application/PingPong/SystemInfoResponse.cs
@@ -5,13 +5,40 @@ namespace iiwi.Model.PingPong;
 
 public record SystemInfoResponse : Response
 {
+    /// <summary>
+    /// Gets or sets the Version.
+    /// </summary>
     public string Version { get; set; } = "1.0.0";
+    /// <summary>
+    /// Gets the Date.
+    /// </summary>
     public string Date => DateTime.Now.ToLongDateString();
+    /// <summary>
+    /// Gets the Time.
+    /// </summary>
     public string Time => DateTime.Now.ToLongTimeString();
+    /// <summary>
+    /// Gets the Assembly.
+    /// </summary>
     public string? Assembly => System.Reflection.Assembly.GetExecutingAssembly().FullName;
+    /// <summary>
+    /// Gets or sets the MachineName.
+    /// </summary>
     public string MachineName { get; set; } = string.Empty;
+    /// <summary>
+    /// Gets the Framework.
+    /// </summary>
     public string Framework => RuntimeInformation.FrameworkDescription;
+    /// <summary>
+    /// Gets the OS.
+    /// </summary>
     public string OS => $"{RuntimeInformation.OSDescription} - ({RuntimeInformation.OSArchitecture})";
+    /// <summary>
+    /// Gets or sets the Author.
+    /// </summary>
     public string Author { get; set; } = string.Empty;
+    /// <summary>
+    /// Gets or sets the Environment.
+    /// </summary>
     public string Environment { get; set; } = string.Empty;
 }

--- a/iiwi.Application/Provider/HttpContextClaimsProvider.cs
+++ b/iiwi.Application/Provider/HttpContextClaimsProvider.cs
@@ -6,7 +6,7 @@ namespace iiwi.Application.Provider;
 public class HttpContextClaimsProvider(IHttpContextAccessor httpContext) : IClaimsProvider
 {
     /// <summary>
-    /// Gets or sets the ClaimsPrinciple.
+    /// Gets the claims principal.
     /// </summary>
     public ClaimsPrincipal ClaimsPrinciple { get; private set; } = httpContext?.HttpContext?.User;
 }

--- a/iiwi.Application/Provider/HttpContextClaimsProvider.cs
+++ b/iiwi.Application/Provider/HttpContextClaimsProvider.cs
@@ -5,5 +5,8 @@ namespace iiwi.Application.Provider;
 
 public class HttpContextClaimsProvider(IHttpContextAccessor httpContext) : IClaimsProvider
 {
+    /// <summary>
+    /// Gets or sets the ClaimsPrinciple.
+    /// </summary>
     public ClaimsPrincipal ClaimsPrinciple { get; private set; } = httpContext?.HttpContext?.User;
 }

--- a/iiwi.Application/Provider/IClaimsProvider.cs
+++ b/iiwi.Application/Provider/IClaimsProvider.cs
@@ -4,5 +4,8 @@ namespace iiwi.Application.Provider;
 
 public interface IClaimsProvider
 {
+    /// <summary>
+    /// Gets the ClaimsPrinciple.
+    /// </summary>
     public ClaimsPrincipal ClaimsPrinciple { get; }
 }

--- a/iiwi.CLI/Helper.cs
+++ b/iiwi.CLI/Helper.cs
@@ -7,6 +7,9 @@ namespace iiwi.CLI;
 
 public static class Helper
 {
+    /// <summary>
+    /// Executes the CreateAddMigrationCommand operation.
+    /// </summary>
     public static Command CreateAddMigrationCommand()
     {
         var command = new Command("add", "Add a new migration");
@@ -36,6 +39,9 @@ public static class Helper
         return command;
     }
 
+    /// <summary>
+    /// Executes the CreateUpdateDatabaseCommand operation.
+    /// </summary>
     public static Command CreateUpdateDatabaseCommand()
     {
         var command = new Command("update", "Update database to latest or specified migration");
@@ -78,6 +84,9 @@ public static class Helper
         return command;
     }
 
+    /// <summary>
+    /// Executes the CreateListMigrationsCommand operation.
+    /// </summary>
     public static Command CreateListMigrationsCommand()
     {
         var command = new Command("list", "List all migrations");
@@ -113,6 +122,9 @@ public static class Helper
         return command;
     }
 
+    /// <summary>
+    /// Executes the CreateRemoveMigrationCommand operation.
+    /// </summary>
     public static Command CreateRemoveMigrationCommand()
     {
         var command = new Command("remove", "Remove the last migration");
@@ -140,6 +152,9 @@ public static class Helper
         return command;
     }
 
+    /// <summary>
+    /// Executes the CreateScriptMigrationCommand operation.
+    /// </summary>
     public static Command CreateScriptMigrationCommand()
     {
         var command = new Command("script", "Generate SQL script for migrations");
@@ -207,6 +222,9 @@ public static class Helper
         return command;
     }
 
+    /// <summary>
+    /// Executes the CreateInfoCommand operation.
+    /// </summary>
     public static Command CreateInfoCommand()
     {
         var command = new Command("info", "Display connection string and configuration information");
@@ -240,6 +258,9 @@ public static class Helper
         return command;
     }
 
+    /// <summary>
+    /// Executes the DisplayInfo operation.
+    /// </summary>
     public static void DisplayInfo(string? project, string? connectionName, string? environment, bool showConnection)
     {
         try
@@ -283,6 +304,9 @@ public static class Helper
         }
     }
 
+    /// <summary>
+    /// Executes the MaskConnectionString operation.
+    /// </summary>
     public static string MaskConnectionString(string connectionString)
     {
         var patterns = new[] { "Password=", "Pwd=", "User ID=", "UID=" };
@@ -305,6 +329,9 @@ public static class Helper
         return result;
     }
 
+    /// <summary>
+    /// Executes the BuildConfiguration operation.
+    /// </summary>
     public static IConfiguration BuildConfiguration(string workingDirectory, string? environment)
     {
         environment ??= "Development";
@@ -318,12 +345,18 @@ public static class Helper
         return builder.Build();
     }
 
+    /// <summary>
+    /// Executes the GetConnectionString operation.
+    /// </summary>
     public static string? GetConnectionString(IConfiguration configuration, string? connectionName)
     {
         connectionName ??= "DefaultConnection";
         return configuration.GetConnectionString(connectionName);
     }
 
+    /// <summary>
+    /// Executes the ExecuteMigrationCommand operation.
+    /// </summary>
     public static async Task ExecuteMigrationCommand(string action, string name, string? context, string? project, string? outputDir)
     {
         try
@@ -354,6 +387,9 @@ public static class Helper
         }
     }
 
+    /// <summary>
+    /// Executes the UpdateDatabase operation.
+    /// </summary>
     public static async Task UpdateDatabase(string? migration, string? context, string? project, string? connection, string? connectionName, string? environment)
     {
         try
@@ -401,6 +437,9 @@ public static class Helper
         }
     }
 
+    /// <summary>
+    /// Executes the ListMigrations operation.
+    /// </summary>
     public static async Task ListMigrations(string? context, string? project, string? connection, string? connectionName, string? environment)
     {
         try
@@ -440,6 +479,9 @@ public static class Helper
         }
     }
 
+    /// <summary>
+    /// Executes the RemoveMigration operation.
+    /// </summary>
     public static async Task RemoveMigration(string? context, string? project, bool force)
     {
         try
@@ -470,6 +512,9 @@ public static class Helper
         }
     }
 
+    /// <summary>
+    /// Executes the ScriptMigration operation.
+    /// </summary>
     public static async Task ScriptMigration(string? from, string? to, string? context, string? project, string? output, bool idempotent, string? connection, string? connectionName, string? environment)
     {
         try
@@ -526,6 +571,9 @@ public static class Helper
         }
     }
 
+    /// <summary>
+    /// Executes the ExecuteDotNetCommand operation.
+    /// </summary>
     public static async Task<int> ExecuteDotNetCommand(string[] args, string? workingDirectory)
     {
         var startInfo = new ProcessStartInfo

--- a/iiwi.Common/Privileges/AccountPermissions.cs
+++ b/iiwi.Common/Privileges/AccountPermissions.cs
@@ -2,13 +2,34 @@
 
 public class AccountPermissions(string moduleName) : PermissionModule(moduleName), IPermissionsModule
 {
+    /// <summary>
+    /// Gets the UpdateProfile.
+    /// </summary>
     public string UpdateProfile => $"{moduleName}.UpdateProfile";
+    /// <summary>
+    /// Gets the DownloadInfo.
+    /// </summary>
     public string DownloadInfo => $"{moduleName}.DownloadInfo";
+    /// <summary>
+    /// Gets the SendVerificationDetails.
+    /// </summary>
     public string SendVerificationDetails => $"{moduleName}.SendVerificationDetails";
+    /// <summary>
+    /// Gets the ChangeEmail.
+    /// </summary>
     public string ChangeEmail => $"{moduleName}.ChangeEmail";
+    /// <summary>
+    /// Gets the DeletePersonalData.
+    /// </summary>
     public string DeletePersonalData => $"{moduleName}.DeletePersonalData";
+    /// <summary>
+    /// Gets the UpdatePhoneNumber.
+    /// </summary>
     public string UpdatePhoneNumber => $"{moduleName}.UpdatePhoneNumber";
 
+    /// <summary>
+    /// Gets the All.
+    /// </summary>
     public override IEnumerable<string> All => base.All.Concat([
         UpdateProfile,
         DeletePersonalData, 

--- a/iiwi.Common/Privileges/AuthenticationPermissions.cs
+++ b/iiwi.Common/Privileges/AuthenticationPermissions.cs
@@ -2,19 +2,61 @@
 
 public class AuthenticationPermissions(string moduleName) : PermissionModule(moduleName), IPermissionsModule
 {
+    /// <summary>
+    /// Gets the LoadKeyAndQrCodeUri.
+    /// </summary>
     public string LoadKeyAndQrCodeUri => $"{moduleName}.LoadKeyAndQrCodeUri";
+    /// <summary>
+    /// Gets the EnableAuthenticator.
+    /// </summary>
     public string EnableAuthenticator => $"{moduleName}.EnableAuthenticator";
+    /// <summary>
+    /// Gets the ExternalLogins.
+    /// </summary>
     public string ExternalLogins => $"{moduleName}.ExternalLogins";
+    /// <summary>
+    /// Gets the RemoveLogin.
+    /// </summary>
     public string RemoveLogin => $"{moduleName}.RemoveLogin";
+    /// <summary>
+    /// Gets the LinkLogin.
+    /// </summary>
     public string LinkLogin => $"{moduleName}.LinkLogin";
+    /// <summary>
+    /// Gets the LinkLoginCallback.
+    /// </summary>
     public string LinkLoginCallback => $"{moduleName}.LinkLoginCallback";
+    /// <summary>
+    /// Gets the GenerateRecoveryCodes.
+    /// </summary>
     public string GenerateRecoveryCodes => $"{moduleName}.GenerateRecoveryCodes";
+    /// <summary>
+    /// Gets the ResetAuthenticator.
+    /// </summary>
     public string ResetAuthenticator => $"{moduleName}.ResetAuthenticator";
+    /// <summary>
+    /// Gets the SetPassword.
+    /// </summary>
     public string SetPassword => $"{moduleName}.SetPassword";
+    /// <summary>
+    /// Gets the ChangePassword.
+    /// </summary>
     public string ChangePassword => $"{moduleName}.ChangePassword";
+    /// <summary>
+    /// Gets the AccountStatus.
+    /// </summary>
     public string AccountStatus => $"{moduleName}.AccountStatus";
+    /// <summary>
+    /// Gets the ForgotBrowser.
+    /// </summary>
     public string ForgotBrowser => $"{moduleName}.ForgotBrowser";
+    /// <summary>
+    /// Gets the Disable2fa.
+    /// </summary>
     public string Disable2fa => $"{moduleName}.Disable2fa";
+    /// <summary>
+    /// Gets the All.
+    /// </summary>
     public override IEnumerable<string> All => base.All.Concat([
         LoadKeyAndQrCodeUri,
         ExternalLogins,

--- a/iiwi.Common/Privileges/AuthorizationPermissions.cs
+++ b/iiwi.Common/Privileges/AuthorizationPermissions.cs
@@ -2,17 +2,53 @@
 
 public class AuthorizationPermissions(string moduleName) : PermissionModule(moduleName), IPermissionsModule
 {
+    /// <summary>
+    /// Gets the AllRoles.
+    /// </summary>
     public string AllRoles => $"{moduleName}.AllRoles";
+    /// <summary>
+    /// Gets the AddRole.
+    /// </summary>
     public string AddRole => $"{moduleName}.AddRole";
+    /// <summary>
+    /// Gets the UpdateRole.
+    /// </summary>
     public string UpdateRole => $"{moduleName}.UpdateRole";
+    /// <summary>
+    /// Gets the DeleteRole.
+    /// </summary>
     public string DeleteRole => $"{moduleName}.DeleteRole";
+    /// <summary>
+    /// Gets the RolesById.
+    /// </summary>
     public string RolesById => $"{moduleName}.RolesById";
+    /// <summary>
+    /// Gets the AddClaim.
+    /// </summary>
     public string AddClaim => $"{moduleName}.AddClaim";
+    /// <summary>
+    /// Gets the AddRoleClaim.
+    /// </summary>
     public string AddRoleClaim => $"{moduleName}.AddRoleClaim";
+    /// <summary>
+    /// Gets the RemoveRoleClaim.
+    /// </summary>
     public string RemoveRoleClaim => $"{moduleName}.RemoveRoleClaim";
+    /// <summary>
+    /// Gets the GetRoleClaims.
+    /// </summary>
     public string GetRoleClaims => $"{moduleName}.GetRoleClaims";
+    /// <summary>
+    /// Gets the AssignRole.
+    /// </summary>
     public string AssignRole => $"{moduleName}.AssignRole";
+    /// <summary>
+    /// Gets the AddUserClaim.
+    /// </summary>
     public string AddUserClaim => $"{moduleName}.AssignRole";
+    /// <summary>
+    /// Gets the All.
+    /// </summary>
     public override IEnumerable<string> All => base.All.Concat([
         AllRoles,
         AddRole,

--- a/iiwi.Common/Privileges/PermissionModule.cs
+++ b/iiwi.Common/Privileges/PermissionModule.cs
@@ -2,13 +2,31 @@
 
 public class PermissionModule(string moduleName)
 {
+    /// <summary>
+    /// Gets the Read.
+    /// </summary>
     public string Read => $"{moduleName}.Read";
+    /// <summary>
+    /// Gets the Create.
+    /// </summary>
     public string Create => $"{moduleName}.Create";
+    /// <summary>
+    /// Gets the Update.
+    /// </summary>
     public string Update => $"{moduleName}.Update";
+    /// <summary>
+    /// Gets the Delete.
+    /// </summary>
     public string Delete => $"{moduleName}.Delete";
 
+    /// <summary>
+    /// Gets the All.
+    /// </summary>
     public virtual IEnumerable<string> All => [Read, Create, Update, Delete];
 
+    /// <summary>
+    /// Executes the For operation.
+    /// </summary>
     public static PermissionModule For(string moduleName) => new(moduleName);
 
     public static TPermissions Permissions<TPermissions>(string moduleName)

--- a/iiwi.Common/Privileges/Permissions.cs
+++ b/iiwi.Common/Privileges/Permissions.cs
@@ -11,6 +11,9 @@ public static class Permissions
     public static readonly AuthenticationPermissions Authentication = PermissionModule.Permissions<AuthenticationPermissions>("Authentication");
     public static readonly AuthorizationPermissions Authorization = PermissionModule.Permissions<AuthorizationPermissions>("Authorization");
 
+    /// <summary>
+    /// Executes the GetAll operation.
+    /// </summary>
     public static IEnumerable<string> GetAll() =>
        AllPermissionModules.SelectMany(module => module);
 

--- a/iiwi.Database/Context/ApplicationDbContext.cs
+++ b/iiwi.Database/Context/ApplicationDbContext.cs
@@ -16,9 +16,15 @@ public sealed class ApplicationDbContext(DbContextOptions<ApplicationDbContext> 
     ApplicationRoleClaim,
     ApplicationUserToken>(options)
 {
+    /// <summary>
+    /// Gets or sets the Permission.
+    /// </summary>
     public DbSet<Permission> Permission { get; set; }
 
     // NOTE: These logs should move to different DbContext 
+    /// <summary>
+    /// Gets or sets the AuditLog.
+    /// </summary>
     public DbSet<AuditLog> AuditLog { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/iiwi.Database/Context/DbContextFactory.cs
+++ b/iiwi.Database/Context/DbContextFactory.cs
@@ -8,6 +8,9 @@ namespace iiwi.Database;
 
 public class DbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
 {
+    /// <summary>
+    /// Executes the CreateDbContext operation.
+    /// </summary>
     public ApplicationDbContext CreateDbContext(string[] args)
     {
         // Get environment

--- a/iiwi.Database/Context/iiwiContextSeed.cs
+++ b/iiwi.Database/Context/iiwiContextSeed.cs
@@ -5,6 +5,9 @@ namespace iiwi.Database;
 
 public static class iiwiContextSeed
 {
+    /// <summary>
+    /// Executes the Seed operation.
+    /// </summary>
     public static void Seed(this ModelBuilder builder) => builder.SeedData();
     private static void SeedData(this ModelBuilder builder)
     {

--- a/iiwi.Database/Context/iiwiDbContextFactory.cs
+++ b/iiwi.Database/Context/iiwiDbContextFactory.cs
@@ -7,6 +7,9 @@ namespace iiwi.Database.Context;
 
 public class iiwiDbContextFactory : IDesignTimeDbContextFactory<iiwiDbContext>
 {
+    /// <summary>
+    /// Executes the CreateDbContext operation.
+    /// </summary>
     public iiwiDbContext CreateDbContext(string[] args)
     {
         // Get environment

--- a/iiwi.Database/Logs/SerilogConfiguration.cs
+++ b/iiwi.Database/Logs/SerilogConfiguration.cs
@@ -6,6 +6,9 @@ namespace iiwi.Database.Logs;
 
 public sealed class SerilogConfiguration : IEntityTypeConfiguration<Serilog>
 {
+    /// <summary>
+    /// Executes the Configure operation.
+    /// </summary>
     public void Configure(EntityTypeBuilder<Serilog> builder)
     {
         builder.ToTable(nameof(Serilog), "Log");

--- a/iiwi.Database/Permissions/PermissionConfiguration.cs
+++ b/iiwi.Database/Permissions/PermissionConfiguration.cs
@@ -8,6 +8,9 @@ namespace iiwi.Database;
 
 public sealed class PermissionConfiguration : IEntityTypeConfiguration<Permission>
 {
+    /// <summary>
+    /// Executes the Configure operation.
+    /// </summary>
     public void Configure(EntityTypeBuilder<Permission> builder)
     {
         builder.ToTable(nameof(Permission), General.Schema.Name);

--- a/iiwi.Database/Permissions/PermissionRepository.cs
+++ b/iiwi.Database/Permissions/PermissionRepository.cs
@@ -13,44 +13,68 @@ namespace iiwi.Database.Permissions;
 
 public class PermissionRepository(ApplicationDbContext context) : EFRepository<Permission>(context), IPermissionRepository
 {
+    /// <summary>
+    /// Gets the Model.
+    /// </summary>
     public static Expression<Func<Permission, PermissionModel>> Model => user => new PermissionModel
     {
         Id = user.Id,
         Name = user.CodeName,
     };
 
+    /// <summary>
+    /// Executes the HasPermissionAsync operation.
+    /// </summary>
     public Task<bool> HasPermissionAsync(int userId, string permissionName)
     {
         throw new NotImplementedException("This method is not implemented yet. Please implement it according to your requirements.");
     }
+    /// <summary>
+    /// Executes the GetPermissionByIdAsync operation.
+    /// </summary>
     public async Task<Permission> GetPermissionByIdAsync(int id)
     {
         return await context.Permission.FindAsync(id);
     }
 
+    /// <summary>
+    /// Executes the GetPermissionByNameAsync operation.
+    /// </summary>
     public async Task<Permission> GetPermissionByNameAsync(string name)
     {
         return await context.Permission
             .FirstOrDefaultAsync(p => p.CodeName == name);
     }
 
+    /// <summary>
+    /// Executes the GetAllPermissionsAsync operation.
+    /// </summary>
     public async Task<IEnumerable<Permission>> GetAllPermissionsAsync()
     {
         return await context.Permission.ToListAsync();
     }
 
+    /// <summary>
+    /// Executes the CreatePermissionAsync operation.
+    /// </summary>
     public async Task CreatePermissionAsync(Permission permission)
     {
         await context.Permission.AddAsync(permission);
         await context.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// Executes the UpdatePermissionAsync operation.
+    /// </summary>
     public async Task UpdatePermissionAsync(Permission permission)
     {
         context.Permission.Update(permission);
         await context.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// Executes the DeletePermissionAsync operation.
+    /// </summary>
     public async Task DeletePermissionAsync(int id)
     {
         await context.Permission
@@ -58,11 +82,17 @@ public class PermissionRepository(ApplicationDbContext context) : EFRepository<P
             .ExecuteDeleteAsync();
     }
 
+    /// <summary>
+    /// Executes the PermissionExistsAsync operation.
+    /// </summary>
     public async Task<bool> PermissionExistsAsync(int id)
     {
         return await context.Permission
             .AnyAsync(p => p.Id == id);
     }
+    /// <summary>
+    /// Executes the GetUserPermissionsAsync operation.
+    /// </summary>
     public Task<List<Permission>> GetUserPermissionsAsync(int userId)
     {
         throw new NotImplementedException("This method is not implemented yet. Please implement it according to your requirements.");

--- a/iiwi.Database/Seeds/PermissionSeeder.cs
+++ b/iiwi.Database/Seeds/PermissionSeeder.cs
@@ -8,6 +8,9 @@ namespace iiwi.Data.Seeds;
 public static class PermissionSeeder
 {
     private static readonly DateTime SeedDate = new(2025, 5, 9, 0, 0, 0, DateTimeKind.Utc);
+    /// <summary>
+    /// Gets the SeedData.
+    /// </summary>
     public static IEnumerable<Permission> SeedData =>
         [.. Permissions.GetAll()
             .Select((permission, index) => new Permission
@@ -19,11 +22,17 @@ public static class PermissionSeeder
                 IsActive = true
             })];
 
+    /// <summary>
+    /// Executes the SeedPermissions operation.
+    /// </summary>
     public static void SeedPermissions(this ModelBuilder modelBuilder)
     {
         _ = modelBuilder.Entity<Permission>().HasData(SeedData);
     }
 
+    /// <summary>
+    /// Executes the SeedPermissions operation.
+    /// </summary>
     public static EntityTypeBuilder<Permission> SeedPermissions(this EntityTypeBuilder<Permission> builder)
     {
         builder.HasData(SeedData);

--- a/iiwi.Domain/Entities/BaseEntity.cs
+++ b/iiwi.Domain/Entities/BaseEntity.cs
@@ -6,23 +6,47 @@ namespace iiwi.Domain;
 
 public abstract class BaseEntity : Entity
 {
+    /// <summary>
+    /// Gets or sets the CreationDate.
+    /// </summary>
     [DataType(DataType.Date)]
     [DisplayFormat(DataFormatString = "{0:yyyy-MM-dd}", ApplyFormatInEditMode = true)]
     public DateTime CreationDate { get; set; }
 
+    /// <summary>
+    /// Gets or sets the UpdateDate.
+    /// </summary>
     [DataType(DataType.Date)]
     [DisplayFormat(DataFormatString = "{0:yyyy-MM-dd}", ApplyFormatInEditMode = true)]
     public DateTime? UpdateDate { get; set; }
 
+    /// <summary>
+    /// Gets or sets the IsDeleted.
+    /// </summary>
     public bool? IsDeleted { get; set; }
+    /// <summary>
+    /// Gets or sets the IsActive.
+    /// </summary>
     public bool IsActive { get; set; } = true;
 
+    /// <summary>
+    /// Gets or sets the DeletedDate.
+    /// </summary>
     [DataType(DataType.Date)]
     [DisplayFormat(DataFormatString = "{0:yyyy-MM-dd}", ApplyFormatInEditMode = true)]
     public DateTime? DeletedDate { get; set; }
 
+    /// <summary>
+    /// Gets or sets the CreatedByUser.
+    /// </summary>
     public virtual ApplicationUser CreatedByUser { get; set; }
+    /// <summary>
+    /// Gets or sets the DeletedByUser.
+    /// </summary>
     public virtual ApplicationUser DeletedByUser { get; set; }
+    /// <summary>
+    /// Gets or sets the UpdateByUser.
+    /// </summary>
     public virtual ApplicationUser UpdateByUser { get; set; }
 }
 

--- a/iiwi.Domain/Identity/ApplicationClaimsPrincipal.cs
+++ b/iiwi.Domain/Identity/ApplicationClaimsPrincipal.cs
@@ -4,5 +4,8 @@ namespace iiwi.Domain.Identity;
 
 public class ApplicationClaimsPrincipal(ClaimsPrincipal principal) : ClaimsPrincipal(principal)
 {
+    /// <summary>
+    /// Gets the UserId.
+    /// </summary>
     public int UserId => int.Parse(FindFirst(ClaimTypes.Sid).Value);
 }

--- a/iiwi.Domain/Identity/ApplicationRole.cs
+++ b/iiwi.Domain/Identity/ApplicationRole.cs
@@ -5,5 +5,8 @@ namespace iiwi.Domain.Identity;
 
 public class ApplicationRole: IdentityRole<int>
 {
+    /// <summary>
+    /// Gets or sets the UserRoles.
+    /// </summary>
     public ICollection<ApplicationUserRole> UserRoles { get; set; } = [];
 }

--- a/iiwi.Domain/Identity/ApplicationUser.cs
+++ b/iiwi.Domain/Identity/ApplicationUser.cs
@@ -5,17 +5,41 @@ namespace iiwi.Domain.Identity;
 
 public class ApplicationUser : IdentityUser<int>
 {
+    /// <summary>
+    /// Gets or sets the Gender.
+    /// </summary>
     [PersonalData]
     public string Gender { get; set; }
+    /// <summary>
+    /// Gets or sets the FirstName.
+    /// </summary>
     [PersonalData]
     public string FirstName { get; set; }
+    /// <summary>
+    /// Gets or sets the LastName.
+    /// </summary>
     [PersonalData]
     public string LastName { get; set; }
+    /// <summary>
+    /// Gets or sets the DisplayName.
+    /// </summary>
     public string DisplayName { get; set; }
+    /// <summary>
+    /// Gets or sets the DOB.
+    /// </summary>
     [PersonalData]
     public DateTime DOB { get; set; }
+    /// <summary>
+    /// Gets or sets the Address.
+    /// </summary>
     public string Address { get; set; }
+    /// <summary>
+    /// Gets or sets the LastLogin.
+    /// </summary>
     public DateTime LastLogin { get; set; }
 
+    /// <summary>
+    /// Gets or sets the UserRoles.
+    /// </summary>
     public virtual ICollection<ApplicationUserRole> UserRoles { get; set; }=[];
 }

--- a/iiwi.Domain/Identity/ApplicationUserRole.cs
+++ b/iiwi.Domain/Identity/ApplicationUserRole.cs
@@ -5,7 +5,16 @@ namespace iiwi.Domain.Identity;
 
 public class ApplicationUserRole: IdentityUserRole<int>
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public int Id { get; set; }
+    /// <summary>
+    /// Gets or sets the User.
+    /// </summary>
     public virtual ApplicationUser User { get; set; } = null!;
+    /// <summary>
+    /// Gets or sets the Role.
+    /// </summary>
     public virtual ApplicationRole Role { get; set; } = null!;
 }

--- a/iiwi.Domain/Logs/ApiLog.cs
+++ b/iiwi.Domain/Logs/ApiLog.cs
@@ -9,53 +9,110 @@ namespace iiwi.Domain.Logs;
 [AuditIgnore]
 public class ApiLog : Entity
 {
+    /// <summary>
+    /// Gets or sets the TraceId.
+    /// </summary>
     [Key]
     public string TraceId { get; set; } // A unique identifier per request
 
+    /// <summary>
+    /// Gets or sets the HttpMethod.
+    /// </summary>
     [Required]
     [MaxLength(10)]
     public string HttpMethod { get; set; } // HTTP method (GET, POST, etc)
 
+    /// <summary>
+    /// Gets or sets the ControllerName.
+    /// </summary>
     [Required]
     [MaxLength(100)]
     public string ControllerName { get; set; } // The controller name
 
+    /// <summary>
+    /// Gets or sets the ActionName.
+    /// </summary>
     [Required]
     [MaxLength(100)]
     public string ActionName { get; set; } // The action name
 
+    /// <summary>
+    /// Gets or sets the FormVariables.
+    /// </summary>
     public string FormVariables { get; set; } // Form-data input variables passed to the action (serialized JSON)
 
+    /// <summary>
+    /// Gets or sets the ActionParameters.
+    /// </summary>
     public string ActionParameters { get; set; } // The action parameters passed (serialized JSON)
 
+    /// <summary>
+    /// Gets or sets the UserName.
+    /// </summary>
     [MaxLength(100)]
     public string UserName { get; set; } // Username on the HttpContext Identity
 
+    /// <summary>
+    /// Gets or sets the RequestUrl.
+    /// </summary>
     [Required]
     public string RequestUrl { get; set; } // URL of the request
 
+    /// <summary>
+    /// Gets or sets the IpAddress.
+    /// </summary>
     [MaxLength(50)]
     public string IpAddress { get; set; } // Client IP address
 
+    /// <summary>
+    /// Gets or sets the ResponseStatusCode.
+    /// </summary>
     public int ResponseStatusCode { get; set; } // HTTP response status code
 
+    /// <summary>
+    /// Gets or sets the ResponseStatus.
+    /// </summary>
     [MaxLength(100)]
     public string ResponseStatus { get; set; } // Response status description
 
+    /// <summary>
+    /// Gets or sets the RequestBody.
+    /// </summary>
     public virtual BodyContent RequestBody { get; set; } // The request body (optional)
 
+    /// <summary>
+    /// Gets or sets the ResponseBody.
+    /// </summary>
     public virtual BodyContent ResponseBody { get; set; } // The response body (optional)
 
+    /// <summary>
+    /// Gets or sets the Headers.
+    /// </summary>
     public string Headers { get; set; } // HTTP Request Headers (serialized JSON, optional)
 
+    /// <summary>
+    /// Gets or sets the ResponseHeaders.
+    /// </summary>
     public string ResponseHeaders { get; set; } // HTTP Response Headers (serialized JSON, optional)
 
+    /// <summary>
+    /// Gets or sets the ModelStateValid.
+    /// </summary>
     public bool ModelStateValid { get; set; } // Boolean to indicate if the model is valid
 
+    /// <summary>
+    /// Gets or sets the ModelStateErrors.
+    /// </summary>
     public string ModelStateErrors { get; set; } // Error description when the model is invalid
 
+    /// <summary>
+    /// Gets or sets the Exception.
+    /// </summary>
     public string Exception { get; set; } // The exception thrown details (if any)
 
+    /// <summary>
+    /// Gets or sets the CreatedAt.
+    /// </summary>
     [Required]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow; // Added for tracking when the log was created
 }
@@ -63,10 +120,19 @@ public class ApiLog : Entity
 [ComplexType]
 public class BodyContent
 {
+    /// <summary>
+    /// Gets or sets the Type.
+    /// </summary>
     [MaxLength(50)]
     public string Type { get; set; } // The body type reported
 
+    /// <summary>
+    /// Gets or sets the Length.
+    /// </summary>
     public long? Length { get; set; } // The length of the body if reported
 
+    /// <summary>
+    /// Gets or sets the Value.
+    /// </summary>
     public string Value { get; set; } // The body content (serialized if complex object)
 }

--- a/iiwi.Domain/Logs/AuditLog.cs
+++ b/iiwi.Domain/Logs/AuditLog.cs
@@ -6,10 +6,10 @@ using System.ComponentModel.DataAnnotations;
 namespace iiwi.Domain.Logs;
 
 
-[AuditIgnore]
 /// <summary>
 /// Represents an audit log entry that tracks changes to entities in the system.
 /// </summary>
+[AuditIgnore]
 public class AuditLog : Entity
 {
     /// <summary>
@@ -21,11 +21,17 @@ public class AuditLog : Entity
     /// <summary>
     /// Gets or sets the type name of the entity that was audited.
     /// </summary>
+    /// <summary>
+    /// Gets or sets the EntityType.
+    /// </summary>
     [MaxLength(100)]
     public string EntityType { get; set; }
 
     /// <summary>
     /// Gets or sets the primary key value of the entity that was audited.
+    /// </summary>
+    /// <summary>
+    /// Gets or sets the EntityName.
     /// </summary>
     [MaxLength(128)]
     public string EntityName { get; set; }
@@ -33,11 +39,17 @@ public class AuditLog : Entity
     /// <summary>
     /// Gets or sets the date and time when the audited action occurred.
     /// </summary>
+    /// <summary>
+    /// Gets or sets the Timestamp.
+    /// </summary>
     [Required]
     public DateTime Timestamp { get; set; }
 
     /// <summary>
     /// Gets or sets the type of action that was performed (e.g., Create, Update, Delete).
+    /// </summary>
+    /// <summary>
+    /// Gets or sets the ActionType.
     /// </summary>
     [MaxLength(20)]
     public string ActionType { get; set; }
@@ -50,6 +62,9 @@ public class AuditLog : Entity
     /// <summary>
     /// Gets or sets the identifier of the user who performed the audited action.
     /// This could be a username, email, or system user ID.
+    /// </summary>
+    /// <summary>
+    /// Gets or sets the PerformedBy.
     /// </summary>
     [MaxLength(100)]
     public string PerformedBy { get; set; }

--- a/iiwi.Domain/Logs/Serilog.cs
+++ b/iiwi.Domain/Logs/Serilog.cs
@@ -3,11 +3,32 @@ namespace iiwi.Domain.Logs;
 
 public class Serilog
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public int Id { get; set; }
+    /// <summary>
+    /// Gets or sets the Message.
+    /// </summary>
     public string Message { get; set; }
+    /// <summary>
+    /// Gets or sets the MessageTemplate.
+    /// </summary>
     public string MessageTemplate { get; set; }
+    /// <summary>
+    /// Gets or sets the Level.
+    /// </summary>
     public string Level { get; set; }
+    /// <summary>
+    /// Gets or sets the TimeStamp.
+    /// </summary>
     public DateTime TimeStamp { get; set; }
+    /// <summary>
+    /// Gets or sets the Exception.
+    /// </summary>
     public string Exception { get; set; }
+    /// <summary>
+    /// Gets or sets the Properties.
+    /// </summary>
     public string Properties { get; set; }
 }

--- a/iiwi.Domain/Permission/Permission.cs
+++ b/iiwi.Domain/Permission/Permission.cs
@@ -2,6 +2,12 @@
 
 public class Permission: BaseEntity
 {
+    /// <summary>
+    /// Gets or sets the CodeName.
+    /// </summary>
     public string CodeName { get; set; }
+    /// <summary>
+    /// Gets or sets the Description.
+    /// </summary>
     public string Description { get; set; } = string.Empty;
 }

--- a/iiwi.Infrastructure/Email/MailRequest.cs
+++ b/iiwi.Infrastructure/Email/MailRequest.cs
@@ -4,8 +4,20 @@ namespace iiwi.Infrastructure.Email;
 
 public class MailRequest
 {
+    /// <summary>
+    /// Gets or sets the ToEmail.
+    /// </summary>
     public string ToEmail { get; set; }
+    /// <summary>
+    /// Gets or sets the Subject.
+    /// </summary>
     public string Subject { get; set; }
+    /// <summary>
+    /// Gets or sets the Body.
+    /// </summary>
     public string Body { get; set; }
+    /// <summary>
+    /// Gets or sets the Attachments.
+    /// </summary>
     public List<IFormFile> Attachments { get; set; }
 }

--- a/iiwi.Infrastructure/Email/MailService.cs
+++ b/iiwi.Infrastructure/Email/MailService.cs
@@ -12,6 +12,9 @@ public class MailService(IOptions<MailSettings> mailSettings) : IMailService
 {
     private readonly MailSettings _mailSettings = mailSettings.Value;
 
+    /// <summary>
+    /// Executes the SendEmailAsync operation.
+    /// </summary>
     public async Task SendEmailAsync(MailRequest mailRequest)
     {
         var email = new MimeMessage
@@ -47,6 +50,9 @@ public class MailService(IOptions<MailSettings> mailSettings) : IMailService
         await smtp.DisconnectAsync(true);
     }
 
+    /// <summary>
+    /// Executes the SendEmailWithTemplateAsync operation.
+    /// </summary>
     public async Task SendEmailWithTemplateAsync(EmailSettings model)
     {
         //FIXME: Dynamic template path.

--- a/iiwi.Infrastructure/Email/MailSettings.cs
+++ b/iiwi.Infrastructure/Email/MailSettings.cs
@@ -2,9 +2,24 @@
 
 public class MailSettings
 {
+    /// <summary>
+    /// Gets or sets the Mail.
+    /// </summary>
     public string Mail { get; set; }
+    /// <summary>
+    /// Gets or sets the DisplayName.
+    /// </summary>
     public string DisplayName { get; set; }
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     public string Password { get; set; }
+    /// <summary>
+    /// Gets or sets the Host.
+    /// </summary>
     public string Host { get; set; }
+    /// <summary>
+    /// Gets or sets the Port.
+    /// </summary>
     public int Port { get; set; }
 }

--- a/iiwi.Library/Helper.cs
+++ b/iiwi.Library/Helper.cs
@@ -156,10 +156,19 @@ public static class Helper
     // Usage in request classes
     public class AddRoleClaimRequest
     {
+        /// <summary>
+        /// Gets or sets the RoleId.
+        /// </summary>
         [FromUrl]
         public int RoleId { get; init; }  // This comes from URL
 
+        /// <summary>
+        /// Gets or sets the ClaimType.
+        /// </summary>
         public string ClaimType { get; init; } = string.Empty;  // This comes from body
+        /// <summary>
+        /// Gets or sets the ClaimValue.
+        /// </summary>
         public string ClaimValue { get; init; } = string.Empty; // This comes from body
     }
 }

--- a/iiwi.Model/Account/ChangeEmailModel.cs
+++ b/iiwi.Model/Account/ChangeEmailModel.cs
@@ -4,6 +4,9 @@ namespace iiwi.Model.Account;
 
 public class ChangeEmailModel
 {
+    /// <summary>
+    /// Gets or sets the NewEmail.
+    /// </summary>
     [Required]
     [EmailAddress]
     [Display(Name = "New email")]

--- a/iiwi.Model/Account/ChangePasswordModel.cs
+++ b/iiwi.Model/Account/ChangePasswordModel.cs
@@ -5,17 +5,26 @@ namespace iiwi.Model.Account;
 
 public class ChangePasswordModel
 {
+    /// <summary>
+    /// Gets or sets the OldPassword.
+    /// </summary>
     [Required]
     [DataType(DataType.Password)]
     [Display(Name = "Current password")]
     public string OldPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the NewPassword.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "New password")]
     public string NewPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm new password")]
     [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]

--- a/iiwi.Model/Account/DeletePersonalDataModel.cs
+++ b/iiwi.Model/Account/DeletePersonalDataModel.cs
@@ -5,6 +5,9 @@ namespace iiwi.Model.Account;
 
 public class DeletePersonalDataModel
 {
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     [Required]
     [DataType(DataType.Password)]
     public string Password { get; set; }

--- a/iiwi.Model/Account/EnableAuthenticatorModel.cs
+++ b/iiwi.Model/Account/EnableAuthenticatorModel.cs
@@ -4,6 +4,9 @@ namespace iiwi.Model.Account;
 
 public class EnableAuthenticatorModel
 {
+    /// <summary>
+    /// Gets or sets the Code.
+    /// </summary>
     [Required]
     [StringLength(7, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Text)]

--- a/iiwi.Model/Account/ExternalLoginsModel.cs
+++ b/iiwi.Model/Account/ExternalLoginsModel.cs
@@ -5,10 +5,22 @@ namespace iiwi.Model.Account;
 
 public class ExternalLoginsModel<T>
 {
+    /// <summary>
+    /// Gets or sets the CurrentLogins.
+    /// </summary>
     public IList<UserLoginInfo> CurrentLogins { get; set; }
 
+    /// <summary>
+    /// Gets or sets the OtherLogins.
+    /// </summary>
     public IList<T> OtherLogins { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ShowRemoveButton.
+    /// </summary>
     public bool ShowRemoveButton { get; set; }
+    /// <summary>
+    /// Gets or sets the StatusMessage.
+    /// </summary>
     public string StatusMessage { get; set; }
 }

--- a/iiwi.Model/Account/ForgotPasswordModel.cs
+++ b/iiwi.Model/Account/ForgotPasswordModel.cs
@@ -5,6 +5,9 @@ namespace iiwi.Model.Account;
 
 public class ForgotPasswordModel
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; }

--- a/iiwi.Model/Account/LoginModel.cs
+++ b/iiwi.Model/Account/LoginModel.cs
@@ -5,14 +5,23 @@ namespace iiwi.Model.Account;
 
 public class LoginModel
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     [Required]
     [DataType(DataType.Password)]
     public string Password { get; set; }
 
+    /// <summary>
+    /// Gets or sets the RememberMe.
+    /// </summary>
     [Display(Name = "Remember me?")]
     public bool RememberMe { get; set; }
 }

--- a/iiwi.Model/Account/LoginWith2faModel.cs
+++ b/iiwi.Model/Account/LoginWith2faModel.cs
@@ -5,12 +5,18 @@ namespace iiwi.Model.Account;
 
 public class LoginWith2faModel
 {
+    /// <summary>
+    /// Gets or sets the TwoFactorCode.
+    /// </summary>
     [Required]
     [StringLength(7, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Text)]
     [Display(Name = "Authenticator code")]
     public string TwoFactorCode { get; set; }
 
+    /// <summary>
+    /// Gets or sets the RememberMachine.
+    /// </summary>
     [Display(Name = "Remember this machine")]
     public bool RememberMachine { get; set; }
 }

--- a/iiwi.Model/Account/LoginWithRecoveryCodeModel.cs
+++ b/iiwi.Model/Account/LoginWithRecoveryCodeModel.cs
@@ -6,6 +6,9 @@ namespace iiwi.Model.Account;
 
 public class LoginWithRecoveryCodeModel
 {
+    /// <summary>
+    /// Gets or sets the RecoveryCode.
+    /// </summary>
     [Required]
     [DataType(DataType.Text)]
     [Display(Name = "Recovery Code")]

--- a/iiwi.Model/Account/RegisterModel.cs
+++ b/iiwi.Model/Account/RegisterModel.cs
@@ -5,17 +5,26 @@ namespace iiwi.Model.Account;
 
 public class RegisterModel
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     [Display(Name = "Email")]
     public string Email { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "Password")]
     public string Password { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm password")]
     [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]

--- a/iiwi.Model/Account/ResetPasswordModel.cs
+++ b/iiwi.Model/Account/ResetPasswordModel.cs
@@ -5,19 +5,31 @@ namespace iiwi.Model.Account;
 
 public class ResetPasswordModel
 {
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     [Required]
     [EmailAddress]
     public string Email { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Password.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     public string Password { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm password")]
     [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
     public string ConfirmPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Code.
+    /// </summary>
     public string Code { get; set; }
 }

--- a/iiwi.Model/Account/SetPasswordModel.cs
+++ b/iiwi.Model/Account/SetPasswordModel.cs
@@ -4,12 +4,18 @@ namespace iiwi.Model.Account;
 
 public class SetPasswordModel
 {
+    /// <summary>
+    /// Gets or sets the NewPassword.
+    /// </summary>
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "New password")]
     public string NewPassword { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ConfirmPassword.
+    /// </summary>
     [DataType(DataType.Password)]
     [Display(Name = "Confirm new password")]
     [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]

--- a/iiwi.Model/Parameters/GetUserQuery.cs
+++ b/iiwi.Model/Parameters/GetUserQuery.cs
@@ -2,6 +2,12 @@
 
 internal class GetUserQuery : UserQuery
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public int Id { get; set; }
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     public string Name { get; set; }
 }

--- a/iiwi.Model/Parameters/QueryParameters.cs
+++ b/iiwi.Model/Parameters/QueryParameters.cs
@@ -1,7 +1,13 @@
 ﻿namespace iiwi.Model.Parameters;
 public abstract class QueryParameters
 {
+    /// <summary>
+    /// Gets or sets the PageNumber.
+    /// </summary>
     public int PageNumber { get; set; } = 0;
 
+    /// <summary>
+    /// Gets or sets the PageSize.
+    /// </summary>
     public int PageSize { get; set; } = 10;
 }

--- a/iiwi.Model/Parameters/SearchUserQuery.cs
+++ b/iiwi.Model/Parameters/SearchUserQuery.cs
@@ -2,5 +2,8 @@
 
 internal class SearchUserQuery : UserQuery
 {
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     public string Name { get; set; }
 }

--- a/iiwi.Model/Parameters/UserQuery.cs
+++ b/iiwi.Model/Parameters/UserQuery.cs
@@ -4,5 +4,8 @@ namespace iiwi.Model.Parameters;
 
 public class UserQuery : QueryParameters
 {
+    /// <summary>
+    /// Gets or sets the NameTypeFacets.
+    /// </summary>
     public string[] NameTypeFacets { get; set; }
 }

--- a/iiwi.Model/Permission/PermissionModel.cs
+++ b/iiwi.Model/Permission/PermissionModel.cs
@@ -3,7 +3,13 @@ namespace iiwi.Model.Permission;
 
 public class PermissionModel
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public long Id { get; init; }
 
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     public required string Name { get; init; }
 }

--- a/iiwi.Model/Records/UserRecord.cs
+++ b/iiwi.Model/Records/UserRecord.cs
@@ -3,11 +3,26 @@ namespace iiwi.Model.Records;
 
 public sealed record UserModel
 {
+    /// <summary>
+    /// Gets or sets the Id.
+    /// </summary>
     public long Id { get; init; }
 
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     public required string Name { get; init; }
 
+    /// <summary>
+    /// Gets or sets the Email.
+    /// </summary>
     public required string Email { get; init; }
+    /// <summary>
+    /// Gets or sets the Status.
+    /// </summary>
     public bool Status { get; set; }
+    /// <summary>
+    /// Gets or sets the PhoneNumber.
+    /// </summary>
     public required string PhoneNumber { get; set; }
 }

--- a/iiwi.Model/Search/UserSearchModel.cs
+++ b/iiwi.Model/Search/UserSearchModel.cs
@@ -5,10 +5,19 @@ namespace iiwi.Model.Search;
 
 public class CustomerSearchModel : IDocument
 {
+    /// <summary>
+    /// Gets the UniqueKey.
+    /// </summary>
     public string UniqueKey => TConst;
 
+    /// <summary>
+    /// Gets or sets the TConst.
+    /// </summary>
     public required string TConst { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     [FacetProperty]
     public required string Name { get; set; }
 }

--- a/iiwi.Model/Settings/EmailSettings.cs
+++ b/iiwi.Model/Settings/EmailSettings.cs
@@ -2,8 +2,20 @@
 
 public class EmailSettings
 {
+    /// <summary>
+    /// Gets or sets the TemplateName.
+    /// </summary>
     public string TemplateName { get; set; }
+    /// <summary>
+    /// Gets or sets the Model.
+    /// </summary>
     public object Model { get; set; }
+    /// <summary>
+    /// Gets or sets the Emails.
+    /// </summary>
     public IList<string> Emails { get; set; }
+    /// <summary>
+    /// Gets or sets the Subject.
+    /// </summary>
     public string Subject { get; set; }
 }

--- a/iiwi.Model/Settings/SettingsOptions.cs
+++ b/iiwi.Model/Settings/SettingsOptions.cs
@@ -7,6 +7,9 @@ public sealed class SettingsOptions
 {
     public const string ConfigurationSectionName = "Application";
 
+    /// <summary>
+    /// Gets or sets the Name.
+    /// </summary>
     [Required]
     [RegularExpression(@"^[a-zA-Z''-'\s]{1,40}$")]
     public required string Name { get; set; }

--- a/iiwi.NetLine/APIDoc/DummiesDoc.cs
+++ b/iiwi.NetLine/APIDoc/DummiesDoc.cs
@@ -8,6 +8,9 @@ namespace iiwi.NetLine.APIDoc;
 public class DummiesDoc
 {
   
+    /// <summary>
+    /// Gets the Group.
+    /// </summary>
     public static EndpointDetails Group => new()
     {
         Name = "Dummies",
@@ -17,6 +20,9 @@ public class DummiesDoc
     };
 
     
+    /// <summary>
+    /// Gets the TestEndpoint.
+    /// </summary>
     public static EndpointDetails TestEndpoint => new()
     {
         Endpoint = "/test",
@@ -25,6 +31,9 @@ public class DummiesDoc
         Description = "This API endpoint can be used for testing basic connectivity and retrieving application meta data."
     };
 
+    /// <summary>
+    /// Gets the AuthTestEndpoint.
+    /// </summary>
     public static EndpointDetails AuthTestEndpoint => new()
     {
         Endpoint = "/test-ping-pong",

--- a/iiwi.NetLine/Builders/Configure.cs
+++ b/iiwi.NetLine/Builders/Configure.cs
@@ -5,44 +5,115 @@ using Microsoft.AspNetCore.HttpLogging;
 
 namespace iiwi.NetLine.Builders;
 
+/// <summary>
+/// Defines metadata and configuration for building a versioned API endpoint.
+/// </summary>
+/// <typeparam name="TEndpoint">The endpoint handler type used to process requests.</typeparam>
+/// <typeparam name="TResponse">The response type returned by the endpoint.</typeparam>
 public class Configure<TEndpoint, TResponse>
     where TEndpoint : class
     where TResponse : class, new()
 {
-    // Required properties
+    /// <summary>
+    /// The delegate invoked when the endpoint executes.
+    /// </summary>
     public Delegate? RequestDelegate { get; set; }
+
+    /// <summary>
+    /// Documentation and routing details used for endpoint metadata and OpenAPI.
+    /// </summary>
     public required EndpointDetails EndpointDetails { get; set; }
 
+    /// <summary>
+    /// Additional per-endpoint configuration applied to the route handler.
+    /// </summary>
     public Action<RouteHandlerBuilder>? AdditionalConfiguration { get; set; }
+
+    /// <summary>
+    /// API versions that this endpoint supports.
+    /// </summary>
     public ApiVersion[] ActiveVersions { get; set; } = [];
+
+    /// <summary>
+    /// API versions that are deprecated for this endpoint.
+    /// </summary>
     public double[] DeprecatedVersions { get; set; } = [];
 
+    /// <summary>
+    /// The HTTP verb associated with the endpoint.
+    /// </summary>
     public HttpVerb HttpMethod { get; set; } = HttpVerb.Get;
     //public bool RequireAuthorization { get; set; } = false; // Deprecated in favor of AuthorizationPolicies
+
+    /// <summary>
+    /// Authorization policies that must be satisfied to access the endpoint.
+    /// </summary>
     public string[] AuthorizationPolicies { get; set; } = [];
+
+    /// <summary>
+    /// Indicates whether response caching is enabled for this endpoint.
+    /// </summary>
     public bool EnableCaching { get; set; } = false;
+
+    /// <summary>
+    /// Indicates whether this endpoint uses URL parameters in its route.
+    /// </summary>
     public bool HasUrlParameters { get; set; } = false;
+
+    /// <summary>
+    /// Caching policy applied when caching is enabled.
+    /// </summary>
     public CachePolicy CachePolicy { get; set; } = CachePolicy.NoCache;
+
+    /// <summary>
+    /// Enables HTTP logging for the endpoint when true.
+    /// </summary>
     public bool EnableHttpLogging { get; set; } = false;
+
+    /// <summary>
+    /// Specifies which HTTP logging fields are captured.
+    /// </summary>
     public HttpLoggingFields HttpLoggingFields { get; set; } = HttpLoggingFields.All;
+
+    /// <summary>
+    /// Names of endpoint filters to attach to the route handler.
+    /// </summary>
     public IEnumerable<string> EndpointFilters { get; set; } = [];
+
+    /// <summary>
+    /// Additional metadata objects added to the endpoint.
+    /// </summary>
     public List<object> EndpointMetadata { get; set; } = [];
 
-    // Helper method to build full endpoint path
+    /// <summary>
+    /// Builds the full, versioned route pattern for the endpoint.
+    /// </summary>
+    /// <returns>The versioned route pattern used by the router.</returns>
     public string BuildEndpointPath()
     {
         return $"v{{version:apiVersion}}{EndpointDetails.Endpoint}";
     }
 }
 
-// Configuration with URL parameters
+/// <summary>
+/// Defines configuration for endpoints that include URL parameters.
+/// </summary>
+/// <typeparam name="TUrlParams">The URL parameter type.</typeparam>
+/// <typeparam name="TRequest">The request payload type.</typeparam>
+/// <typeparam name="TResponse">The response type returned by the endpoint.</typeparam>
 public class Configure<TUrlParams, TRequest, TResponse>
     : Configure<TRequest, TResponse>
     where TUrlParams : class, new()
     where TRequest : class, new()
     where TResponse : class, new()
 {
-    // URL parameters specific properties
+    /// <summary>
+    /// Combines URL parameters with the request payload into a single request instance.
+    /// </summary>
     public Func<TUrlParams, TRequest, TRequest>? CombineParameters { get; set; }
+
+    /// <summary>
+    /// Enables validation of URL parameters before request handling.
+    /// </summary>
     public bool ValidateUrlParameters { get; set; } = true;
 }

--- a/iiwi.NetLine/Builders/EndpointBuilder.cs
+++ b/iiwi.NetLine/Builders/EndpointBuilder.cs
@@ -64,10 +64,22 @@ public class EndpointConfigurator<TRequest, TResponse>(
     where TRequest : class, new()
     where TResponse : class, new()
 {
+    /// <summary>
+    /// Gets the Builder.
+    /// </summary>
     public RouteHandlerBuilder Builder { get; } = builder;
+    /// <summary>
+    /// Gets the Configuration.
+    /// </summary>
     public Configure<TRequest, TResponse> Configuration { get; } = configuration;
+    /// <summary>
+    /// Gets the ApiVersionSet.
+    /// </summary>
     public ApiVersionSet ApiVersionSet { get; } = apiVersionSet;
 
+    /// <summary>
+    /// Executes the ApplyMetadata operation.
+    /// </summary>
     public EndpointConfigurator<TRequest, TResponse> ApplyMetadata()
     {
         Builder.WithMetadata(Configuration.EndpointMetadata)
@@ -75,6 +87,9 @@ public class EndpointConfigurator<TRequest, TResponse>(
         return this;
     }
 
+    /// <summary>
+    /// Executes the ApplyAuthentication operation.
+    /// </summary>
     public EndpointConfigurator<TRequest, TResponse> ApplyAuthentication()
     {
         if (Configuration.AuthorizationPolicies.Length > 0)
@@ -88,6 +103,9 @@ public class EndpointConfigurator<TRequest, TResponse>(
         return this;
     }
 
+    /// <summary>
+    /// Executes the ApplyCaching operation.
+    /// </summary>
     public EndpointConfigurator<TRequest, TResponse> ApplyCaching()
     {
         if (Configuration.EnableCaching && Configuration.CachePolicy != CachePolicy.NoCache)
@@ -97,6 +115,9 @@ public class EndpointConfigurator<TRequest, TResponse>(
         return this;
     }
 
+    /// <summary>
+    /// Executes the ApplyLogging operation.
+    /// </summary>
     public EndpointConfigurator<TRequest, TResponse> ApplyLogging()
     {
         if (Configuration.EnableHttpLogging)
@@ -106,6 +127,9 @@ public class EndpointConfigurator<TRequest, TResponse>(
         return this;
     }
 
+    /// <summary>
+    /// Executes the ApplyFilters operation.
+    /// </summary>
     public EndpointConfigurator<TRequest, TResponse> ApplyFilters()
     {
         if (Configuration.EndpointFilters?.Any() == true)
@@ -115,6 +139,9 @@ public class EndpointConfigurator<TRequest, TResponse>(
         return this;
     }
 
+    /// <summary>
+    /// Executes the ApplyVersioning operation.
+    /// </summary>
     public EndpointConfigurator<TRequest, TResponse> ApplyVersioning()
     {
         Builder.WithApiVersionSet(ApiVersionSet);

--- a/iiwi.NetLine/Config/ApiVersioningSetup.cs
+++ b/iiwi.NetLine/Config/ApiVersioningSetup.cs
@@ -3,6 +3,9 @@ namespace iiwi.NetLine.Config;
 
 public static class ApiVersioningSetup
 {
+    /// <summary>
+    /// Executes the ApiVersioning operation.
+    /// </summary>
     public static IServiceCollection ApiVersioning(this IServiceCollection services, Action<ApiVersioningConfig> configure = null)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/iiwi.NetLine/Config/AppServicesSetup.cs
+++ b/iiwi.NetLine/Config/AppServicesSetup.cs
@@ -20,7 +20,7 @@ namespace iiwi.NetLine.Config;
 /// - Email services
 /// - Application-specific providers
 /// </remarks>
-public static class AppServicesesSetup
+public static class AppServicesSetup
 {
     /// <summary>
     /// Registers all application services with the dependency injection container
@@ -50,11 +50,11 @@ public static class AppServicesesSetup
     /// Usage Example:
     /// <code>
     /// var builder = WebApplication.CreateBuilder(args);
-    /// builder.Services.AddAppServiceses(builder.Configuration);
+    /// builder.Services.AddAppServices(builder.Configuration);
     /// </code>
     /// </para>
     /// </remarks>
-    public static IServiceCollection AddAppServiceses(this IServiceCollection services, ConfigurationManager configuration)
+    public static IServiceCollection AddAppServices(this IServiceCollection services, ConfigurationManager configuration)
     {
         ArgumentNullException.ThrowIfNull(services);
 

--- a/iiwi.NetLine/Config/EnvironmentSetup.cs
+++ b/iiwi.NetLine/Config/EnvironmentSetup.cs
@@ -85,7 +85,7 @@ public static class EnvironmentSetup
             });
 
             // Extended liveness check - tagged services
-            app.MapHealthChecks("healthz/alive", new HealthCheckOptions
+            app.MapHealthChecks("/healthz/alive", new HealthCheckOptions
             {
                 Predicate = r => r.Tags.Contains("live"),
                 ResponseWriter = HealthCheckerResponse.WriteResponse,

--- a/iiwi.NetLine/Config/IdentitySetup.cs
+++ b/iiwi.NetLine/Config/IdentitySetup.cs
@@ -72,6 +72,9 @@ public static class IdentitySetup
         return services;
     }
 
+    /// <summary>
+    /// Executes the UseIdentity operation.
+    /// </summary>
     public static void UseIdentity(this WebApplication app)
     {
         ArgumentNullException.ThrowIfNull(app);

--- a/iiwi.NetLine/Endpoints/Endpoint.cs
+++ b/iiwi.NetLine/Endpoints/Endpoint.cs
@@ -8,30 +8,84 @@ public abstract class Endpoint<TRequest, TResponse>
     where TResponse : class, new()
 {
     // Configuration
+    /// <summary>
+    /// Gets the RoutePattern.
+    /// </summary>
     public abstract string RoutePattern { get; }
+    /// <summary>
+    /// Gets the HttpMethods.
+    /// </summary>
     public abstract IEnumerable<string> HttpMethods { get; }
+    /// <summary>
+    /// Gets the Documentation.
+    /// </summary>
     public abstract object Documentation { get; }
+    /// <summary>
+    /// Gets the ActiveVersions.
+    /// </summary>
     public abstract ApiVersion[] ActiveVersions { get; }
 
     // Optional configuration with defaults
+    /// <summary>
+    /// Gets the RouteGroupPrefix.
+    /// </summary>
     public virtual string RouteGroupPrefix => string.Empty;
+    /// <summary>
+    /// Gets the GroupName.
+    /// </summary>
     public virtual string GroupName => "API";
+    /// <summary>
+    /// Gets the DeprecatedVersions.
+    /// </summary>
     public virtual double[] DeprecatedVersions => Array.Empty<double>();
+    /// <summary>
+    /// Gets the RequireAuthorization.
+    /// </summary>
     public virtual bool RequireAuthorization => false;
+    /// <summary>
+    /// Gets the AuthorizationPolicies.
+    /// </summary>
     public virtual string[] AuthorizationPolicies => Array.Empty<string>();
+    /// <summary>
+    /// Gets the EnableCaching.
+    /// </summary>
     public virtual bool EnableCaching => false;
+    /// <summary>
+    /// Gets the CachePolicy.
+    /// </summary>
     public virtual string CachePolicy => "DefaultPolicy";
+    /// <summary>
+    /// Gets the EnableHttpLogging.
+    /// </summary>
     public virtual bool EnableHttpLogging => false;
+    /// <summary>
+    /// Gets the HttpLoggingFields.
+    /// </summary>
     public virtual HttpLoggingFields HttpLoggingFields => HttpLoggingFields.All;
+    /// <summary>
+    /// Gets the EndpointFilters.
+    /// </summary>
     public virtual IEndpointFilter[] EndpointFilters => Array.Empty<IEndpointFilter>();
+    /// <summary>
+    /// Gets the EndpointMetadata.
+    /// </summary>
     public virtual List<object> EndpointMetadata => new();
 
     // Abstract method to handle the request
+    /// <summary>
+    /// Executes the HandleAsync operation.
+    /// </summary>
     public abstract Task<TResponse> HandleAsync(TRequest request, IServiceProvider serviceProvider, CancellationToken cancellationToken = default);
 
     // Virtual method for additional configuration
+    /// <summary>
+    /// Executes the ConfigureEndpoint operation.
+    /// </summary>
     public virtual void ConfigureEndpoint(RouteHandlerBuilder builder) { }
 
     // Build full endpoint path
+    /// <summary>
+    /// Executes the BuildEndpointPath operation.
+    /// </summary>
     public string BuildEndpointPath() => $"v{{version:apiVersion}}{RoutePattern}";
 }

--- a/iiwi.NetLine/Endpoints/PingPong.cs
+++ b/iiwi.NetLine/Endpoints/PingPong.cs
@@ -38,6 +38,9 @@ public class PingPong
         Description = "This API endpoint can be used for testing basic connectivity and retrieving application meta data."
     };
 
+    /// <summary>
+    /// Gets the SystemInfoEndpoint.
+    /// </summary>
     public static EndpointDetails SystemInfoEndpoint => new()
     {
         Endpoint = "/system/info",

--- a/iiwi.NetLine/Extentions/ApiVersioningExtensions.cs
+++ b/iiwi.NetLine/Extentions/ApiVersioningExtensions.cs
@@ -11,6 +11,9 @@ namespace iiwi.NetLine.Extentions;
 
 public static class ApiVersioningExtensions
 {
+    /// <summary>
+    /// Executes the ConfigureApiVersioning operation.
+    /// </summary>
     public static void ConfigureApiVersioning(this ApiVersioningOptions options, ApiVersioningConfig config)
     {
         options.AssumeDefaultVersionWhenUnspecified = config.AssumeDefaultVersion;
@@ -28,6 +31,9 @@ public static class ApiVersioningExtensions
         }
     }
 
+    /// <summary>
+    /// Executes the CreateVersionReaders operation.
+    /// </summary>
     public static IApiVersionReader CreateVersionReaders()
     {
         return ApiVersionReader.Combine(
@@ -38,6 +44,9 @@ public static class ApiVersioningExtensions
         );
     }
 
+    /// <summary>
+    /// Executes the ConfigureSunsetPolicy operation.
+    /// </summary>
     public static void ConfigureSunsetPolicy(this ApiVersioningOptions options, ApiVersioningConfig config)
     {
         options.Policies.Sunset(config.SunsetVersion)
@@ -47,6 +56,9 @@ public static class ApiVersioningExtensions
             .Type(config.PolicyContentType);
     }
 
+    /// <summary>
+    /// Executes the ConfigureApiExplorer operation.
+    /// </summary>
     public static void ConfigureApiExplorer(this ApiExplorerOptions options, ApiVersioningConfig config)
     {
         options.GroupNameFormat = config.GroupNameFormat;
@@ -56,20 +68,59 @@ public static class ApiVersioningExtensions
     // Configuration class for better maintainability
     public class ApiVersioningConfig
     {
+        /// <summary>
+        /// Gets or sets the AssumeDefaultVersion.
+        /// </summary>
         public bool AssumeDefaultVersion { get; set; } = true;
+        /// <summary>
+        /// Gets or sets the DefaultApiVersion.
+        /// </summary>
         public ApiVersion DefaultApiVersion { get; set; } = new ApiVersion(1, 0);
+        /// <summary>
+        /// Gets or sets the ReportApiVersions.
+        /// </summary>
         public bool ReportApiVersions { get; set; } = true;
+        /// <summary>
+        /// Gets or sets the EnableMultipleVersionReaders.
+        /// </summary>
         public bool EnableMultipleVersionReaders { get; set; } = true;
+        /// <summary>
+        /// Gets or sets the EnableSunsetPolicy.
+        /// </summary>
         public bool EnableSunsetPolicy { get; set; } = true;
+        /// <summary>
+        /// Gets or sets the SunsetVersion.
+        /// </summary>
         public double SunsetVersion { get; set; } = 0.9;
+        /// <summary>
+        /// Gets or sets the SunsetDays.
+        /// </summary>
         public int SunsetDays { get; set; } = 60;
+        /// <summary>
+        /// Gets or sets the PolicyLink.
+        /// </summary>
         public string PolicyLink { get; set; } = "policy.html";
+        /// <summary>
+        /// Gets or sets the PolicyTitle.
+        /// </summary>
         public string PolicyTitle { get; set; } = "Versioning Policy";
+        /// <summary>
+        /// Gets or sets the PolicyContentType.
+        /// </summary>
         public string PolicyContentType { get; set; } = "text/html";
+        /// <summary>
+        /// Gets or sets the GroupNameFormat.
+        /// </summary>
         public string GroupNameFormat { get; set; } = "'v'VVV";
+        /// <summary>
+        /// Gets or sets the SubstituteInUrl.
+        /// </summary>
         public bool SubstituteInUrl { get; set; } = true;
     }
 
+    /// <summary>
+    /// Executes the CreateApiVersionSet operation.
+    /// </summary>
     public static ApiVersionSet CreateApiVersionSet(IEndpointRouteBuilder endpoints)
     {
         return endpoints.NewApiVersionSet()
@@ -80,6 +131,9 @@ public static class ApiVersioningExtensions
             .Build();
     }
 
+    /// <summary>
+    /// Executes the WithApiVersion operation.
+    /// </summary>
     public static RouteHandlerBuilder WithApiVersion(this RouteHandlerBuilder builder, ApiVersionSet apiVersion)
     {
         return builder.WithApiVersionSet(apiVersion)

--- a/iiwi.NetLine/Extentions/EndpointFilterExtension.cs
+++ b/iiwi.NetLine/Extentions/EndpointFilterExtension.cs
@@ -2,6 +2,9 @@
 
 public static class EndpointFilterExtension
 {
+    /// <summary>
+    /// Executes the AddFiltersByNames operation.
+    /// </summary>
     public static void AddFiltersByNames(this RouteHandlerBuilder builder, IEnumerable<string> filterNames)
     {
         var assemblyName = typeof(Program).Assembly.GetName().Name;

--- a/iiwi.NetLine/Extentions/IdentityExtensions.cs
+++ b/iiwi.NetLine/Extentions/IdentityExtensions.cs
@@ -616,7 +616,13 @@ public static class IdentityExtensions
     {
         private IEndpointConventionBuilder InnerAsConventionBuilder => inner;
 
+        /// <summary>
+        /// Executes the Add operation.
+        /// </summary>
         public void Add(Action<EndpointBuilder> convention) => InnerAsConventionBuilder.Add(convention);
+        /// <summary>
+        /// Executes the Finally operation.
+        /// </summary>
         public void Finally(Action<EndpointBuilder> finallyConvention) => InnerAsConventionBuilder.Finally(finallyConvention);
     }
 
@@ -633,6 +639,9 @@ public static class IdentityExtensions
     [AttributeUsage(AttributeTargets.Parameter)]
     private sealed class FromQueryAttribute : Attribute, IFromQueryMetadata
     {
+        /// <summary>
+        /// Gets the Name.
+        /// </summary>
         public string Name => null;
     }
 }

--- a/iiwi.NetLine/Modules/PingPongModules.cs
+++ b/iiwi.NetLine/Modules/PingPongModules.cs
@@ -12,6 +12,9 @@ namespace iiwi.NetLine.Modules;
 
 public class PingPongModules : IEndpoints
 {
+    /// <summary>
+    /// Executes the AddRoutes operation.
+    /// </summary>
     public void AddRoutes(IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);

--- a/iiwi.NetLine/Program.cs
+++ b/iiwi.NetLine/Program.cs
@@ -48,7 +48,7 @@ builder.Services.AddIdentity(config);
 builder.Services.AddAuditTrail(config);   // Enhanced version with config
 
 // Register core application services
-builder.Services.AddAppServiceses(config); // Main business logic services
+builder.Services.AddAppServices(config); // Main business logic services
 builder.Services.AddAuthorization();      // Authorization policies
 builder.Services.AddAppCache();           // Caching infrastructure
 builder.Services.AddMediator(nameof(iiwi)); // MediatR for CQRS

--- a/iiwi.NetLine/Swagger/NamedSwaggerGenOptions.cs
+++ b/iiwi.NetLine/Swagger/NamedSwaggerGenOptions.cs
@@ -8,11 +8,17 @@ namespace iiwi.NetLine.Swagger;
 
 public class NamedSwaggerGenOptions(IApiVersionDescriptionProvider provider) : IConfigureNamedOptions<SwaggerGenOptions>
 {
+    /// <summary>
+    /// Executes the Configure operation.
+    /// </summary>
     public void Configure(string? name, SwaggerGenOptions options)
     {
         Configure(options);
     }
 
+    /// <summary>
+    /// Executes the Configure operation.
+    /// </summary>
     public void Configure(SwaggerGenOptions options)
     {
         // add swagger document for every API version discovered

--- a/iiwi.NetLine/Swagger/SwaggerUIExtensions.cs
+++ b/iiwi.NetLine/Swagger/SwaggerUIExtensions.cs
@@ -5,6 +5,9 @@ namespace iiwi.NetLine.Swagger;
 
 public static class SwaggerUIExtensions
 {
+    /// <summary>
+    /// Executes the ConfigureApiEndpoints operation.
+    /// </summary>
     public static SwaggerUIOptions ConfigureApiEndpoints(this SwaggerUIOptions options, WebApplication app)
     {
         var descriptions = app.DescribeApiVersions();

--- a/iiwi.SearchEngine.Tests/LuceneQueryBuilderTests.cs
+++ b/iiwi.SearchEngine.Tests/LuceneQueryBuilderTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using iiwi.SearchEngine.Models;
+using iiwi.SearchEngine.Queries;
+using Lucene.Net.Search;
+using Xunit;
+
+namespace iiwi.SearchEngine.Tests;
+
+public class LuceneQueryBuilderTests
+{
+    private sealed class SampleDocument : IDocument
+    {
+        /// <summary>
+        /// Gets or sets the UniqueKey.
+        /// </summary>
+        public string UniqueKey { get; init; } = string.Empty;
+        /// <summary>
+        /// Gets or sets the Title.
+        /// </summary>
+        public string Title { get; init; } = string.Empty;
+        /// <summary>
+        /// Gets or sets the Description.
+        /// </summary>
+        public string Description { get; init; } = string.Empty;
+        /// <summary>
+        /// Gets or sets the Tags.
+        /// </summary>
+        public string[] Tags { get; init; } = Array.Empty<string>();
+        /// <summary>
+        /// Gets or sets the Count.
+        /// </summary>
+        public int Count { get; init; }
+    }
+
+    /// <summary>
+    /// Executes the ConstructQuery_ReturnsMatchAll_WhenSearchFieldsAreNull operation.
+    /// </summary>
+    [Fact]
+    public void ConstructQuery_ReturnsMatchAll_WhenSearchFieldsAreNull()
+    {
+        var query = LuceneQueryBuilder.ConstructQuery<SampleDocument>(null, SearchType.ExactMatch);
+
+        Assert.IsType<MatchAllDocsQuery>(query);
+    }
+
+    /// <summary>
+    /// Executes the ConstructQuery_ReturnsMatchAll_WhenOnlyUnsupportedFieldsProvided operation.
+    /// </summary>
+    [Fact]
+    public void ConstructQuery_ReturnsMatchAll_WhenOnlyUnsupportedFieldsProvided()
+    {
+        var searchFields = new Dictionary<string, string?>
+        {
+            ["Count"] = "5"
+        };
+
+        var query = LuceneQueryBuilder.ConstructQuery<SampleDocument>(searchFields, SearchType.ExactMatch);
+
+        Assert.IsType<MatchAllDocsQuery>(query);
+    }
+
+    /// <summary>
+    /// Executes the ConstructQuery_BuildsExpectedQueryType operation.
+    /// </summary>
+    [Theory]
+    [InlineData(SearchType.ExactMatch, typeof(TermQuery))]
+    [InlineData(SearchType.PrefixMatch, typeof(PrefixQuery))]
+    [InlineData(SearchType.FuzzyMatch, typeof(FuzzyQuery))]
+    public void ConstructQuery_BuildsExpectedQueryType(SearchType searchType, Type expectedQueryType)
+    {
+        var searchFields = new Dictionary<string, string?>
+        {
+            ["Title"] = "search"
+        };
+
+        var query = LuceneQueryBuilder.ConstructQuery<SampleDocument>(searchFields, searchType);
+
+        var booleanQuery = Assert.IsType<BooleanQuery>(query);
+        var clause = Assert.Single(booleanQuery.Clauses);
+        Assert.IsType(expectedQueryType, clause.Query);
+    }
+
+    /// <summary>
+    /// Executes the ConstructFulltextSearchQuery_CreatesFuzzyAndWildcardQueriesForEachField operation.
+    /// </summary>
+    [Fact]
+    public void ConstructFulltextSearchQuery_CreatesFuzzyAndWildcardQueriesForEachField()
+    {
+        var searchQuery = new FullTextSearchQuery
+        {
+            SearchTerm = "focus"
+        };
+
+        var query = LuceneQueryBuilder.ConstructFulltextSearchQuery<SampleDocument>(searchQuery);
+
+        Assert.Equal(4, query.Clauses.Count);
+        Assert.Contains(query.Clauses, clause => clause.Query is FuzzyQuery);
+        Assert.Contains(query.Clauses, clause => clause.Query is WildcardQuery);
+    }
+}

--- a/iiwi.SearchEngine.Tests/iiwi.SearchEngine.Tests.csproj
+++ b/iiwi.SearchEngine.Tests/iiwi.SearchEngine.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../iiwi.SearchEngine/iiwi.SearchEngine.csproj" />
+  </ItemGroup>
+</Project>

--- a/iiwi.SearchEngine/AssemblyInfo.cs
+++ b/iiwi.SearchEngine/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("iiwi.SearchEngine.Tests")]

--- a/iiwi.slnx
+++ b/iiwi.slnx
@@ -11,4 +11,5 @@
   <Project Path="iiwi.NetLine/iiwi.NetLine.csproj" />
   <Project Path="iiwi.Scheduler/iiwi.Scheduler.csproj" />
   <Project Path="iiwi.SearchEngine/iiwi.SearchEngine.csproj" />
+  <Project Path="iiwi.SearchEngine.Tests/iiwi.SearchEngine.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics and generated API/docs by adding XML documentation to public types and members across the solution for clearer IntelliSense and OpenAPI metadata.
- Fix an awkward API name and surface area by renaming the service-registration helper to a natural name and update usages accordingly.
- Provide initial unit test coverage for the search engine component and tidy a few small runtime issues (health path) discovered during review.

### Description
- Added XML documentation comments for public properties, methods, constructors, and configuration types across multiple projects including `iiwi.Application`, `iiwi.Domain`, `iiwi.Model`, `iiwi.Infrastructure`, `iiwi.Library`, and `iiwi.NetLine`, and cleaned duplicate/ misplaced comment blocks so doc comments are placed above attributes when appropriate.
- Renamed `AppServicesesSetup`/`AddAppServiceses` to `AppServicesSetup`/`AddAppServices` and updated `Program.cs` to call `builder.Services.AddAppServices(config);`.
- Updated README and CONTRIBUTING with a project structure snippet and a fixed documentation link, and corrected the healthcheck mapping to include a leading slash (`/healthz/alive`).
- Added `iiwi.SearchEngine.Tests` with `LuceneQueryBuilderTests.cs`, an `AssemblyInfo.cs` to expose internals to the tests, and included the test project in the solution file `iiwi.slnx`.

### Testing
- No automated tests were executed as part of this change.
- Unit tests were added under `iiwi.SearchEngine.Tests` but have not been run in CI or locally as part of this change.
- A local script was used to insert and normalize XML comments and the resulting changes were compiled into the commit without running `dotnet test`.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981aae58ab88327a99711dcc78ef5a1)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds XML documentation across public APIs, renames the DI registration helper to AppServicesSetup/AddAppServices, and introduces initial search engine unit tests. Also fixes the healthcheck route and a broken docs link, and updates the README with project structure.

- **New Features**
  - Added iiwi.SearchEngine.Tests with initial Lucene query builder tests; exposed internals via AssemblyInfo and added to the solution.

- **Refactors**
  - Added XML docs to public types and members across Application, Domain, Infrastructure, Database, Common, CLI, Library, and Model for clearer IntelliSense/OpenAPI.
  - Renamed AppServicesesSetup/AddAppServiceses to AppServicesSetup/AddAppServices and updated usages.
  - Fixed healthcheck path to /healthz/alive and corrected CONTRIBUTING docs link; README now includes a project structure overview.

<sup>Written for commit 1dea4671a010e386a0b750ec0673ba7bc500d745. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added password confirmation field to password change, reset, and set password flows for enhanced security.
  * Expanded user profile fields to include gender, first name, last name, display name, date of birth, address, and last login timestamp.
  * Extended permissions system with new authentication and authorization permission keys for enhanced access control.
  * Enhanced API versioning and endpoint configuration capabilities for improved API management.

* **Documentation**
  * Comprehensive XML documentation added throughout codebase for better developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->